### PR TITLE
Add `MigStatus` / `Status_Specification` "O"

### DIFF
--- a/src/fundamend/models/messageimplementationguide.py
+++ b/src/fundamend/models/messageimplementationguide.py
@@ -19,6 +19,7 @@ class MigStatus(StrEnum):
     R = "R"
     N = "N"
     D = "D"
+    O = "O"
 
 
 @dataclass(kw_only=True, eq=True)


### PR DESCRIPTION
fixes 'ValueError: 'O' is not a valid MigStatus'