### PR TITLE
Add ahb_status field to DataElement class

### DIFF
--- a/src/fundamend/models/anwendungshandbuch.py
+++ b/src/fundamend/models/anwendungshandbuch.py
@@ -34,6 +34,7 @@ class DataElement(FundamendBaseModel):
     # </D_0065>
     id: str  # e.g. 'D_0065'
     name: str  # e.g. 'Nachrichtentyp-Kennung'
+    ahb_status: str | None  # e.g. 'X'
     codes: tuple[Code, ...]
 
 

--- a/src/fundamend/reader/ahbreader.py
+++ b/src/fundamend/reader/ahbreader.py
@@ -91,9 +91,13 @@ def _to_data_element(element: ET.Element) -> DataElement:
             codes.append(_to_code(child))
         else:
             raise ValueError(f"unexpected element: {child.tag}")
+    ahb_status: str | None = None
+    if "AHB_Status" in element.attrib and element.attrib["AHB_Status"].strip():
+        ahb_status = element.attrib["AHB_Status"]
     return DataElement(
         id=element.tag,
         name=element.attrib["Name"],
+        ahb_status=ahb_status,
         codes=tuple(codes),
     )
 


### PR DESCRIPTION
This PR adds the `ahb_status` field (currently part of the `SegmentGroup`, `Segment`, and `Code` classes) to the `DataElement` class and extends the AHB reader to fill in the field when creating `DataElement` instances.