### PR TITLE
perf(ci): restrict checks before PyPI push to tests (no coverage)

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -30,9 +30,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install tox
-      - name: Run tox
+      - name: Run tests
         run: |
-          tox
+          tox -e tests
 
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI


### PR DESCRIPTION
Instead of tests + ... `<sequential other faster checks>` ... + coverage .
The coverage run alone doubles the time it takes and adds only minimal value at this place. so we omit it