### PR TITLE
perf(v_ahb_diff): replace NOT EXISTS with LEFT JOIN for better query performance

### DIFF
--- a/src/fundamend/sqlmodels/create_ahb_diff_view.sql
+++ b/src/fundamend/sqlmodels/create_ahb_diff_view.sql
@@ -128,12 +128,11 @@ FROM version_pairs vp
 JOIN v_ahbtabellen new_tbl
     ON new_tbl.format_version = vp.new_format_version
     AND new_tbl.pruefidentifikator = vp.new_pruefidentifikator
-WHERE NOT EXISTS (
-    SELECT 1 FROM v_ahbtabellen old_tbl
-    WHERE old_tbl.format_version = vp.old_format_version
-      AND old_tbl.pruefidentifikator = vp.old_pruefidentifikator
-      AND old_tbl.id_path = new_tbl.id_path
-)
+LEFT JOIN v_ahbtabellen old_check
+    ON old_check.format_version = vp.old_format_version
+    AND old_check.pruefidentifikator = vp.old_pruefidentifikator
+    AND old_check.id_path = new_tbl.id_path
+WHERE old_check.id_path IS NULL
 
 UNION ALL
 
@@ -171,9 +170,8 @@ FROM version_pairs vp
 JOIN v_ahbtabellen old_tbl
     ON old_tbl.format_version = vp.old_format_version
     AND old_tbl.pruefidentifikator = vp.old_pruefidentifikator
-WHERE NOT EXISTS (
-    SELECT 1 FROM v_ahbtabellen new_tbl
-    WHERE new_tbl.format_version = vp.new_format_version
-      AND new_tbl.pruefidentifikator = vp.new_pruefidentifikator
-      AND new_tbl.id_path = old_tbl.id_path
-);
+LEFT JOIN v_ahbtabellen new_check
+    ON new_check.format_version = vp.new_format_version
+    AND new_check.pruefidentifikator = vp.new_pruefidentifikator
+    AND new_check.id_path = old_tbl.id_path
+WHERE new_check.id_path IS NULL;


### PR DESCRIPTION
…performance

The v_ahb_diff view used NOT EXISTS subqueries to detect added and deleted rows. These correlated subqueries execute once per row, which can be slow especially when SQLite cannot optimize the subquery efficiently.

This change replaces the two NOT EXISTS patterns with LEFT JOIN + IS NULL:
- Added rows: LEFT JOIN old version, WHERE old.id_path IS NULL
- Deleted rows: LEFT JOIN new version, WHERE new.id_path IS NULL

LEFT JOIN allows SQLite to use index lookups directly during the join phase rather than running a separate subquery for each candidate row. This is a well-known SQL optimization pattern that typically performs better across database engines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)