### PR TITLE
Revert "perf(v_ahb_diff): replace NOT EXISTS with LEFT JOIN for better query performance (#225)"

### DIFF
--- a/src/fundamend/sqlmodels/create_ahb_diff_view.sql
+++ b/src/fundamend/sqlmodels/create_ahb_diff_view.sql
@@ -128,11 +128,12 @@ FROM version_pairs vp
 JOIN v_ahbtabellen new_tbl
     ON new_tbl.format_version = vp.new_format_version
     AND new_tbl.pruefidentifikator = vp.new_pruefidentifikator
-LEFT JOIN v_ahbtabellen old_check
-    ON old_check.format_version = vp.old_format_version
-    AND old_check.pruefidentifikator = vp.old_pruefidentifikator
-    AND old_check.id_path = new_tbl.id_path
-WHERE old_check.id_path IS NULL
+WHERE NOT EXISTS (
+    SELECT 1 FROM v_ahbtabellen old_tbl
+    WHERE old_tbl.format_version = vp.old_format_version
+      AND old_tbl.pruefidentifikator = vp.old_pruefidentifikator
+      AND old_tbl.id_path = new_tbl.id_path
+)
 
 UNION ALL
 
@@ -170,8 +171,9 @@ FROM version_pairs vp
 JOIN v_ahbtabellen old_tbl
     ON old_tbl.format_version = vp.old_format_version
     AND old_tbl.pruefidentifikator = vp.old_pruefidentifikator
-LEFT JOIN v_ahbtabellen new_check
-    ON new_check.format_version = vp.new_format_version
-    AND new_check.pruefidentifikator = vp.new_pruefidentifikator
-    AND new_check.id_path = old_tbl.id_path
-WHERE new_check.id_path IS NULL;
+WHERE NOT EXISTS (
+    SELECT 1 FROM v_ahbtabellen new_tbl
+    WHERE new_tbl.format_version = vp.new_format_version
+      AND new_tbl.pruefidentifikator = vp.new_pruefidentifikator
+      AND new_tbl.id_path = old_tbl.id_path
+);


### PR DESCRIPTION
This reverts commit 00945092b5885ba55e0de558b3fc9d04fc2b2147.
Manual tests show, that it's not faster with the LEFT JOIN approach. At least not for prüfi=13009, FV2510 / FV2604.
