### PR TITLE
perf(tests): parallelize CI test runs with pytest-xdist

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,8 +24,6 @@ jobs:
       - name: Install dependencies
         run: uv sync --group coverage --extra sqlmodels --extra ahbicht --extra cli
       - name: Run Tests and Record Coverage
-        run: |
-          cd unittests
-          uv run coverage run -m pytest -vv
-          uv run coverage html --omit .venv/*,unittests/*
-          uv run coverage report --fail-under 94 --omit .venv/*,unittests/*
+        # pytest-cov aggregates coverage across the pytest-xdist worker subprocesses
+        # (plain `coverage run` would miss them once the suite runs with `-n auto`).
+        run: uv run pytest -vv --cov=fundamend --cov-report=html --cov-report=term --cov-fail-under=94

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,6 +23,18 @@ jobs:
           python-version: "3.14"
       - name: Install dependencies
         run: uv sync --group coverage --extra sqlmodels --extra ahbicht --extra cli
+      - name: Determine submodule revision for the DB cache key
+        id: submodule
+        run: echo "sha=$(git -C xml-migs-and-ahbs rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Cache built test databases
+        # Shares the deterministic, content-addressed SQLite DB cache across runs (see
+        # unittests/_db_cache.py) keyed on the pinned submodule commit.
+        uses: actions/cache@v4
+        with:
+          path: .pytest_db_cache
+          key: pytest-db-cache-v1-${{ steps.submodule.outputs.sha }}
+          restore-keys: |
+            pytest-db-cache-v1-
       - name: Run Tests and Record Coverage
         # pytest-cov aggregates coverage across the pytest-xdist worker subprocesses
         # (plain `coverage run` would miss them once the suite runs with `-n auto`).

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Dependencies
         run: uv sync --group tests --extra sqlmodels --extra ahbicht
       - name: install typer if requested
-        if: matrix.run_step == 'install_typer'
+        if: matrix.cli == 'install_typer'
         run: uv sync --group tests --extra sqlmodels --extra ahbicht --extra cli
       - name: Run the Unit Tests
         run: uv run pytest -vv

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -31,5 +31,19 @@ jobs:
       - name: install typer if requested
         if: matrix.cli == 'install_typer'
         run: uv sync --group tests --extra sqlmodels --extra ahbicht --extra cli
+      - name: Determine submodule revision for the DB cache key
+        id: submodule
+        run: echo "sha=$(git -C xml-migs-and-ahbs rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Cache built test databases
+        # The tests build deterministic SQLite DBs from the pinned submodule XML; cache them keyed
+        # on the submodule commit so unchanged data isn't re-parsed on every run. The cache content
+        # is additionally content-addressed (see unittests/_db_cache.py), so a stale restore is
+        # simply ignored rather than reused incorrectly.
+        uses: actions/cache@v4
+        with:
+          path: .pytest_db_cache
+          key: pytest-db-cache-v1-${{ steps.submodule.outputs.sha }}
+          restore-keys: |
+            pytest-db-cache-v1-
       - name: Run the Unit Tests
         run: uv run pytest -vv

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+.pytest_db_cache/
 
 # Translations
 *.mo

--- a/README.md
+++ b/README.md
@@ -349,6 +349,48 @@ Das fundamend Datenmodell ist auch als JSON Schema verfügbar: [`json_schemas`](
 Der Code ist MIT-lizenziert und kann daher frei verwendet werden.
 Wir freuen uns über Pull Requests an den main-Branch dieses Repositories.
 
+### Tests ausführen
+Die Tests laufen mit `pytest` und werden über `pytest-xdist` parallel auf allen CPU-Kernen ausgeführt
+(`-n auto --dist loadfile`, konfiguriert in `pyproject.toml`):
+
+```bash
+uv run pytest
+```
+
+Ein einzelner Worker lässt sich mit `uv run pytest -n0` erzwingen (z.B. zum Debuggen).
+
+### Datenbank-Cache der Tests
+Viele Tests bauen SQLite-Datenbanken aus den XML-Dateien des privaten Submoduls `xml-migs-and-ahbs`.
+Das ist teuer (XML-Parsing + `ahbicht`-Ausdrucksauswertung), weshalb die fertig gebauten Datenbanken
+zwischengespeichert werden:
+
+- **Lokal:** unter `.pytest_db_cache/` (gitignored), gemeinsam genutzt von allen xdist-Workern.
+- **In der CI:** ein `actions/cache`-Schritt speichert `.pytest_db_cache/` unter einem Schlüssel, der auf
+  den ausgecheckten Commit des Submoduls `xml-migs-and-ahbs` zeigt. So werden unveränderte Daten nicht
+  bei jedem Lauf neu geparst.
+
+Jeder Cache-Eintrag ist inhaltsadressiert (siehe `unittests/_db_cache.py`). Der Fingerprint umfasst
+`_CACHE_VERSION`, die Bauvariante sowie Pfad, Gültigkeitsdaten **und Inhalt** aller Eingabe-XML-Dateien.
+Ein Eintrag wird nur wiederverwendet, wenn der Fingerprint exakt passt – andernfalls wird die Datenbank
+neu gebaut.
+
+**Automatische Aktualisierung (kein Eingriff nötig):** Ändert sich der Inhalt der AHB/MIG-XML-Dateien –
+insbesondere wenn das Submodul auf einen neuen Commit gesetzt wird –, ändert sich der Fingerprint und die
+betroffene Datenbank wird beim nächsten Testlauf einmalig neu gebaut. In der CI wird dann unter dem neuen
+Submodul-Commit automatisch ein neuer Cache abgelegt.
+
+**Manuelle Aktualisierung nötig:** Der Fingerprint hasht die *Eingaben*, nicht den *Baucode*. Wenn sich
+die **Art und Weise ändert, wie eine Datenbank gebaut wird** (SQL-Views, Materialisierung, Spalten oder
+die `ahbicht`-Logik in `create_db_and_populate_with_ahb_view`, `create_and_fill_ahb_expression_table`,
+den View-Erzeugern usw.), bleiben Eingaben und damit Fingerprint gleich – eine veraltete Datenbank würde
+weiterverwendet. In diesem Fall muss `_CACHE_VERSION` in `unittests/_db_cache.py` erhöht werden
+(z.B. `"v1"` → `"v2"`), um alle Fingerprints auf einmal zu invalidieren.
+
+Hinweise: GitHub entfernt Caches nach 7 Tagen ohne Zugriff oder beim Überschreiten des Cache-Limits (10 GB);
+ein Cache kann also gelegentlich verschwinden und wird dann einmalig neu gebaut. Das `v1` im
+*Workflow*-Schlüssel (`.github/workflows/unittests.yml` bzw. `coverage.yml`) ist ein separater Hebel, um
+den gesamten CI-Cache zu verwerfen.
+
 ## Hochfrequenz
 Die [Hochfrequenz Unternehmensberatung GmbH](https://www.hochfrequenz.de) ist eine Beratung für Energieversorger im deutschsprachigen Raum.
 Wir arbeiten größtenteils remote, haben aber auch Büros in Berlin, Bremen, Leipzig, Köln und Grünwald und attraktive [Stellenangebote](https://www.hochfrequenz.de/index.php/karriere/aktuelle-stellenausschreibungen/full-stack-entwickler).

--- a/domain-specific-terms.txt
+++ b/domain-specific-terms.txt
@@ -20,3 +20,7 @@ contrl
 Elemente
 segmente
 hierarchie
+lokal
+unter
+passt
+separater

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ cli = [
 
 [dependency-groups]
 tests = [
+    "filelock==3.32.2",
     "pytest==9.1.1",
     "pytest-xdist==3.8.0",
     "syrupy==5.5.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ cli = [
 [dependency-groups]
 tests = [
     "pytest==9.1.1",
+    "pytest-xdist==3.8.0",
     "syrupy==5.5.3"
 ]
 lint = [
@@ -53,6 +54,7 @@ spell_check = [
 ]
 coverage = [
     "coverage==7.15.2",
+    "pytest-cov==7.1.0",
     {include-group = "tests"}
 ]
 dev = [
@@ -94,6 +96,11 @@ ignore = [
 
 [tool.pytest.ini_options]
 markers = ["snapshot: mark a test as a snapshot test"]
+# -n auto runs the suite across all CPU cores; --dist loadfile keeps every test in a
+# module on the same worker so module-scoped DB fixtures are built once per module.
+addopts = "-n auto --dist loadfile"
+# keep the noisy ahbicht/lark expression parser from formatting DEBUG/INFO log lines during test capture
+log_level = "WARNING"
 
 [project.scripts]
 xml2json = "fundamend.__main__:main"

--- a/unittests/_db_cache.py
+++ b/unittests/_db_cache.py
@@ -1,0 +1,83 @@
+"""
+On-disk cache for the expensive SQLite databases the tests build from the AHB/MIG XML corpus.
+
+The XML source lives in the pinned ``xml-migs-and-ahbs`` submodule and the database builders in
+:mod:`fundamend.sqlmodels` are deterministic, so a given ``(input files, flags)`` combination always
+produces an equivalent database. Building one is slow (XML parsing plus ``ahbicht`` expression
+evaluation) and the suite triggers dozens of such builds, so we cache the finished ``.sqlite`` file
+on disk keyed by a content hash of its inputs.
+
+The cache is shared across pytest-xdist workers through the filesystem (guarded by a file lock so a
+cold cache is built exactly once) and can additionally be persisted across CI runs via an
+``actions/cache`` step keyed on the submodule commit -- see ``.github/workflows``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import tempfile
+from collections.abc import Callable, Iterable
+from datetime import date
+from pathlib import Path
+
+from filelock import FileLock
+
+# Bump when the *way* a cached database is built changes (new views, different columns, ...), so
+# that stale cache entries from an older builder are ignored instead of silently reused.
+_CACHE_VERSION = "v1"
+
+_CACHE_DIR = Path(__file__).parent.parent / ".pytest_db_cache"
+
+# Type of the file lists accepted by fundamend's DB builders.
+_AhbFile = Path | tuple[Path, date, date | None] | tuple[Path, None, None]
+
+
+def fingerprint(recipe: str, files: Iterable[_AhbFile]) -> str:
+    """
+    Return a short, stable hash identifying a database build.
+
+    ``recipe`` names the build variant (e.g. which views get added on top); ``files`` is the exact
+    input set. Both the file *paths* and their *content* are hashed, so the fingerprint is correct
+    even if the submodule is checked out at a different commit or locally modified. The file order
+    does not matter -- inputs are sorted first.
+    """
+    hasher = hashlib.sha256()
+    hasher.update(_CACHE_VERSION.encode())
+    hasher.update(recipe.encode())
+    normalized: list[tuple[str, str, str]] = []
+    for item in files:
+        if isinstance(item, Path):
+            path, von, bis = item, "", ""
+        else:
+            path = item[0]
+            von = "" if item[1] is None else item[1].isoformat()
+            bis = "" if item[2] is None else item[2].isoformat()
+        normalized.append((str(path), von, bis))
+    for path_str, von, bis in sorted(normalized):
+        hasher.update(path_str.encode())
+        hasher.update(von.encode())
+        hasher.update(bis.encode())
+        hasher.update(Path(path_str).read_bytes())
+    return hasher.hexdigest()[:32]
+
+
+def cached_db(key: str, builder: Callable[[], Path]) -> Path:
+    """
+    Return a path to a ready-to-use SQLite database for ``key``, building it once and caching it.
+
+    On a cache miss ``builder`` is invoked (exactly once across all xdist workers, thanks to the
+    file lock) and its result is published into the cache. Every caller receives its *own* fresh
+    copy of the cached file, so concurrent sessions never contend on a single database file.
+    """
+    _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    cached = _CACHE_DIR / f"{key}.sqlite"
+    with FileLock(f"{cached}.lock"):
+        if not cached.exists():
+            built = builder()
+            tmp = cached.with_suffix(".sqlite.building")
+            shutil.copyfile(built, tmp)
+            tmp.replace(cached)  # atomic publish so readers never see a half-written file
+    consumer_copy = Path(tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False).name)
+    shutil.copyfile(cached, consumer_copy)
+    return consumer_copy

--- a/unittests/conftest.py
+++ b/unittests/conftest.py
@@ -2,8 +2,11 @@ import logging
 from collections.abc import Generator, Iterable, Sequence
 from datetime import date
 from pathlib import Path
+from typing import Any
 
 import pytest
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
 from sqlmodel import Session, create_engine
 
 from fundamend.sqlmodels import (
@@ -28,6 +31,28 @@ example_files_root = Path(__file__).parent / "example_files"
 
 def is_private_submodule_checked_out() -> bool:
     return any(private_submodule_root.iterdir())
+
+
+def apply_throwaway_sqlite_pragmas(engine: Engine) -> None:
+    """
+    Register non-durable SQLite PRAGMAs on ``engine`` for throwaway test databases.
+
+    Tests that round-trip many MIGs/AHBs commit repeatedly into a temporary SQLite file; with the
+    default ``synchronous=FULL`` every commit fsyncs, which dominated the runtime of the
+    "all from submodule" tests. Since these databases are discarded at the end of the test, we can
+    safely turn durability off.
+    """
+
+    def _set_sqlite_pragmas(dbapi_connection: Any, _connection_record: Any) -> None:
+        cursor = dbapi_connection.cursor()
+        try:
+            cursor.execute("PRAGMA synchronous=OFF")
+            cursor.execute("PRAGMA journal_mode=MEMORY")
+            cursor.execute("PRAGMA temp_store=MEMORY")
+        finally:
+            cursor.close()
+
+    event.listen(engine, "connect", _set_sqlite_pragmas)
 
 
 # =============================================================================

--- a/unittests/conftest.py
+++ b/unittests/conftest.py
@@ -1,14 +1,20 @@
 import logging
-from collections.abc import Generator
+from collections.abc import Generator, Iterable, Sequence
 from datetime import date
 from pathlib import Path
 
 import pytest
 from sqlmodel import Session, create_engine
 
-from fundamend.sqlmodels import create_ahbtabellen_view, create_db_and_populate_with_ahb_view
+from fundamend.sqlmodels import (
+    create_ahbtabellen_view,
+    create_db_and_populate_with_ahb_view,
+    create_db_and_populate_with_mig_view,
+)
 from fundamend.sqlmodels.ahb_diff_view import create_ahb_diff_view
 from fundamend.sqlmodels.expression_view import create_and_fill_ahb_expression_table
+
+from ._db_cache import _AhbFile, cached_db, fingerprint
 
 # The ahbicht condition-expression parser (and its lark backend) can emit large volumes of
 # DEBUG/INFO log lines while the expensive DB fixtures parse every AHB expression. Formatting
@@ -25,6 +31,54 @@ def is_private_submodule_checked_out() -> bool:
 
 
 # =============================================================================
+# Cached database builders
+# =============================================================================
+# The DB builders in fundamend.sqlmodels are deterministic, so identical inputs always yield an
+# equivalent database. Building one is slow (XML parsing + ahbicht), so these helpers serve the
+# result from an on-disk cache shared across pytest-xdist workers (see unittests/_db_cache.py).
+# =============================================================================
+
+
+def cached_ahb_db(ahb_files: Iterable[_AhbFile], drop_raw_tables: bool = False) -> Path:
+    """
+    Like :func:`create_db_and_populate_with_ahb_view`, but served from the on-disk cache.
+
+    The returned database is equivalent to a fresh build (same deterministic inserts and view), so
+    callers -- including snapshot tests -- observe identical query results while the underlying
+    XML parsing/materialization happens only once per unique input set.
+    """
+    ahb_files = list(ahb_files)
+    recipe = f"ahb_raw_drop{int(drop_raw_tables)}"
+    key = f"{recipe}_{fingerprint(recipe, ahb_files)}"
+    return cached_db(
+        key, lambda: create_db_and_populate_with_ahb_view(ahb_files=ahb_files, drop_raw_tables=drop_raw_tables)
+    )
+
+
+def cached_mig_db(mig_files: Iterable[_AhbFile], drop_raw_tables: bool = False) -> Path:
+    """MIG counterpart of :func:`cached_ahb_db`."""
+    mig_files = list(mig_files)
+    recipe = f"mig_raw_drop{int(drop_raw_tables)}"
+    key = f"{recipe}_{fingerprint(recipe, mig_files)}"
+    return cached_db(
+        key, lambda: create_db_and_populate_with_mig_view(mig_files=mig_files, drop_raw_tables=drop_raw_tables)
+    )
+
+
+def _build_ahb_db_with_diff_view(ahb_files: Sequence[_AhbFile]) -> Path:
+    """Build a complete AHB database file: raw tables + expression table + ahbtabellen + diff view."""
+    db_path = create_db_and_populate_with_ahb_view(ahb_files=ahb_files, drop_raw_tables=False)
+    engine = create_engine(f"sqlite:///{db_path}")
+    with Session(bind=engine) as session:
+        create_and_fill_ahb_expression_table(session)
+        create_ahbtabellen_view(session)
+        create_ahb_diff_view(session)
+        session.commit()
+    engine.dispose()
+    return db_path
+
+
+# =============================================================================
 # Shared Database Fixtures with Meaningful Names
 # =============================================================================
 # These fixtures are module-scoped to speed up tests by reusing expensive DB creation.
@@ -38,23 +92,22 @@ def session_fv2410_fv2504_with_diff_view() -> Generator[Session, None, None]:
     Module-scoped fixture providing a database session with FV2410 and FV2504 data.
     Includes: ahb_hierarchy_materialized, ahb_expressions, v_ahbtabellen, v_ahb_diff.
 
-    This fixture is expensive to create (~30s), so it's shared across all tests that need
-    to compare FV2410 and FV2504.
+    This fixture is expensive to create, so the fully-built database is served from the on-disk
+    cache and shared across all tests (and CI runs) that need to compare FV2410 and FV2504.
     """
     if not is_private_submodule_checked_out():
         pytest.skip("Skipping test because of missing private submodule")
 
-    ahb_paths = [
+    ahb_files: Sequence[_AhbFile] = [
         (p, date(2024, 10, 1), date(2025, 6, 6)) for p in (private_submodule_root / "FV2410").rglob("**/*AHB*.xml")
     ] + [(p, date(2025, 6, 6), None) for p in (private_submodule_root / "FV2504").rglob("**/*AHB*.xml")]
 
-    actual_sqlite_path = create_db_and_populate_with_ahb_view(ahb_files=ahb_paths, drop_raw_tables=False)
-    engine = create_engine(f"sqlite:///{actual_sqlite_path}")
+    recipe = "ahb_fv2410_fv2504_with_diff_view"
+    db_path = cached_db(f"{recipe}_{fingerprint(recipe, ahb_files)}", lambda: _build_ahb_db_with_diff_view(ahb_files))
+    engine = create_engine(f"sqlite:///{db_path}")
     with Session(bind=engine) as session:
-        create_and_fill_ahb_expression_table(session)
-        create_ahbtabellen_view(session)
-        create_ahb_diff_view(session)
         yield session
+    engine.dispose()
 
 
 @pytest.fixture(scope="module")
@@ -67,15 +120,14 @@ def session_fv2510_fv2604_mscons_with_diff_view() -> Generator[Session, None, No
     if not is_private_submodule_checked_out():
         pytest.skip("Skipping test because of missing private submodule")
 
-    ahb_paths = [
+    ahb_files: Sequence[_AhbFile] = [
         (p, date(2025, 10, 1), date(2026, 4, 1))
         for p in (private_submodule_root / "FV2510").rglob("**/MSCONS_AHB*.xml")
     ] + [(p, date(2026, 4, 1), None) for p in (private_submodule_root / "FV2604").rglob("**/MSCONS_AHB*.xml")]
 
-    actual_sqlite_path = create_db_and_populate_with_ahb_view(ahb_files=ahb_paths, drop_raw_tables=False)
-    engine = create_engine(f"sqlite:///{actual_sqlite_path}")
+    recipe = "ahb_fv2510_fv2604_mscons_with_diff_view"
+    db_path = cached_db(f"{recipe}_{fingerprint(recipe, ahb_files)}", lambda: _build_ahb_db_with_diff_view(ahb_files))
+    engine = create_engine(f"sqlite:///{db_path}")
     with Session(bind=engine) as session:
-        create_and_fill_ahb_expression_table(session)
-        create_ahbtabellen_view(session)
-        create_ahb_diff_view(session)
         yield session
+    engine.dispose()

--- a/unittests/conftest.py
+++ b/unittests/conftest.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Generator
 from datetime import date
 from pathlib import Path
@@ -8,6 +9,12 @@ from sqlmodel import Session, create_engine
 from fundamend.sqlmodels import create_ahbtabellen_view, create_db_and_populate_with_ahb_view
 from fundamend.sqlmodels.ahb_diff_view import create_ahb_diff_view
 from fundamend.sqlmodels.expression_view import create_and_fill_ahb_expression_table
+
+# The ahbicht condition-expression parser (and its lark backend) can emit large volumes of
+# DEBUG/INFO log lines while the expensive DB fixtures parse every AHB expression. Formatting
+# those lines during pytest's log capture is pure overhead, so pin these loggers to WARNING.
+logging.getLogger("ahbicht").setLevel(logging.WARNING)
+logging.getLogger("lark").setLevel(logging.WARNING)
 
 private_submodule_root = Path(__file__).parent.parent / "xml-migs-and-ahbs"
 example_files_root = Path(__file__).parent / "example_files"

--- a/unittests/test_ahb_diff_view.py
+++ b/unittests/test_ahb_diff_view.py
@@ -5,10 +5,10 @@ from efoli import EdifactFormatVersion
 from sqlmodel import Session, create_engine, select, text
 from syrupy.assertion import SnapshotAssertion
 
-from fundamend.sqlmodels import create_ahbtabellen_view, create_db_and_populate_with_ahb_view
+from fundamend.sqlmodels import create_ahbtabellen_view
 from fundamend.sqlmodels.ahb_diff_view import AhbDiffLine, create_ahb_diff_view
 
-from .conftest import is_private_submodule_checked_out, private_submodule_root
+from .conftest import cached_ahb_db, is_private_submodule_checked_out, private_submodule_root
 
 
 @pytest.mark.snapshot
@@ -23,7 +23,7 @@ def test_ahb_diff_view_various_pruefis(snapshot: SnapshotAssertion) -> None:
         (p, date(2024, 10, 1), date(2025, 6, 6)) for p in (private_submodule_root / "FV2410").rglob("**/*AHB*.xml")
     ] + [(p, date(2025, 6, 6), None) for p in (private_submodule_root / "FV2504").rglob("**/*AHB*.xml")]
 
-    actual_sqlite_path = create_db_and_populate_with_ahb_view(ahb_files=ahb_paths, drop_raw_tables=False)
+    actual_sqlite_path = cached_ahb_db(ahb_paths, drop_raw_tables=False)
     assert actual_sqlite_path.exists()
     engine = create_engine(f"sqlite:///{actual_sqlite_path}")
     results: list[AhbDiffLine] = []

--- a/unittests/test_mig_views.py
+++ b/unittests/test_mig_views.py
@@ -22,7 +22,7 @@ from fundamend.sqlmodels import (
     create_mig_view,
 )
 
-from .conftest import is_private_submodule_checked_out, private_submodule_root
+from .conftest import cached_mig_db, is_private_submodule_checked_out, private_submodule_root
 
 
 @pytest.fixture()
@@ -147,7 +147,7 @@ def test_mig_diff_view_with_two_versions() -> None:
         (fv2504_migs[0], date(2025, 6, 6), None),
     ]
 
-    actual_sqlite_path = create_db_and_populate_with_mig_view(mig_files=mig_paths, drop_raw_tables=False)
+    actual_sqlite_path = cached_mig_db(mig_files=mig_paths, drop_raw_tables=False)
     engine = create_engine(f"sqlite:///{actual_sqlite_path}")
 
     with Session(bind=engine) as session:
@@ -205,7 +205,7 @@ def test_mig_hierarchy_all_from_submodule() -> None:
     # Use just the first few MIGs to keep test reasonable
     mig_paths = mig_paths[:5]
 
-    actual_sqlite_path = create_db_and_populate_with_mig_view(mig_files=mig_paths)
+    actual_sqlite_path = cached_mig_db(mig_files=mig_paths)
     assert actual_sqlite_path.exists()
 
     engine = create_engine(f"sqlite:///{actual_sqlite_path}")
@@ -233,7 +233,7 @@ def test_mig_diff_snapshot_comdis(snapshot: SnapshotAssertion) -> None:
         (fv2504_comdis, date(2025, 6, 6), None),
     ]
 
-    actual_sqlite_path = create_db_and_populate_with_mig_view(mig_files=mig_paths, drop_raw_tables=False)
+    actual_sqlite_path = cached_mig_db(mig_files=mig_paths, drop_raw_tables=False)
     engine = create_engine(f"sqlite:///{actual_sqlite_path}")
 
     with Session(bind=engine) as session:
@@ -271,7 +271,7 @@ def test_mig_diff_snapshot_pricat(snapshot: SnapshotAssertion) -> None:
         (fv2504_pricat, date(2025, 6, 6), None),
     ]
 
-    actual_sqlite_path = create_db_and_populate_with_mig_view(mig_files=mig_paths, drop_raw_tables=False)
+    actual_sqlite_path = cached_mig_db(mig_files=mig_paths, drop_raw_tables=False)
     engine = create_engine(f"sqlite:///{actual_sqlite_path}")
 
     with Session(bind=engine) as session:
@@ -309,7 +309,7 @@ def test_mig_diff_snapshot_iftsta(snapshot: SnapshotAssertion) -> None:
         (fv2510_iftsta, date(2025, 10, 1), None),
     ]
 
-    actual_sqlite_path = create_db_and_populate_with_mig_view(mig_files=mig_paths, drop_raw_tables=False)
+    actual_sqlite_path = cached_mig_db(mig_files=mig_paths, drop_raw_tables=False)
     engine = create_engine(f"sqlite:///{actual_sqlite_path}")
 
     with Session(bind=engine) as session:

--- a/unittests/test_sqlmodels_anwendungshandbuch.py
+++ b/unittests/test_sqlmodels_anwendungshandbuch.py
@@ -19,7 +19,7 @@ from fundamend.models.kommunikationsrichtung import Kommunikationsrichtung
 from fundamend.sqlmodels import AhbHierarchyMaterialized, create_ahb_view, create_db_and_populate_with_ahb_view
 from fundamend.sqlmodels import Anwendungshandbuch as SqlAnwendungshandbuch
 
-from .conftest import is_private_submodule_checked_out
+from .conftest import cached_ahb_db, is_private_submodule_checked_out
 
 
 @pytest.fixture()
@@ -184,7 +184,7 @@ def test_create_sqlite_from_submodule() -> None:
         pytest.skip("Skipping test because of missing private submodule")
     private_submodule_root = Path(__file__).parent.parent / "xml-migs-and-ahbs"
     assert private_submodule_root.exists() and private_submodule_root.is_dir()
-    actual_sqlite_path = create_db_and_populate_with_ahb_view(list(private_submodule_root.rglob("**/*AHB*.xml")))
+    actual_sqlite_path = cached_ahb_db(list(private_submodule_root.rglob("**/*AHB*.xml")))
     assert actual_sqlite_path.exists()
 
 
@@ -195,7 +195,7 @@ def test_create_sqlite_from_submodule_with_validity() -> None:
     relevant_files = [
         (p, date(2024, 10, 1), date(2025, 6, 6)) for p in (private_submodule_root / "FV2410").rglob("**/*AHB*.xml")
     ] + [(p, date(2025, 6, 6), None) for p in (private_submodule_root / "FV2504").rglob("**/*AHB*.xml")]
-    actual_sqlite_path = create_db_and_populate_with_ahb_view(relevant_files, drop_raw_tables=True)
+    actual_sqlite_path = cached_ahb_db(relevant_files, drop_raw_tables=True)
     assert actual_sqlite_path.exists()
     engine = create_engine(f"sqlite:///{actual_sqlite_path}")
     with Session(bind=engine) as session:
@@ -286,7 +286,7 @@ def test_sqlmodels_all_id_path_uniqueness(format_version: str, gueltig_von: date
     if not format_version_path.exists():
         pytest.skip(f"Format version {format_version} not found in submodule")
     relevant_files = [(p, gueltig_von, gueltig_bis) for p in format_version_path.rglob("**/*AHB*.xml")]
-    actual_sqlite_path = create_db_and_populate_with_ahb_view(relevant_files, drop_raw_tables=False)
+    actual_sqlite_path = cached_ahb_db(relevant_files, drop_raw_tables=False)
     _check_uniqueness_of_id_paths(actual_sqlite_path)
 
 
@@ -321,7 +321,7 @@ def test_id_path_uniqueness_per_message_type(message_type: str) -> None:
     ]
     if not relevant_files:
         pytest.skip(f"No AHB files found for {message_type}")
-    actual_sqlite_path = create_db_and_populate_with_ahb_view(relevant_files, drop_raw_tables=False)
+    actual_sqlite_path = cached_ahb_db(relevant_files, drop_raw_tables=False)
     _check_uniqueness_of_id_paths(actual_sqlite_path)
     _check_id_paths_use_qualifiers_not_sort_path(actual_sqlite_path)
 
@@ -343,7 +343,7 @@ def test_id_path_stable_across_versions_utilmd() -> None:
     ] + [(p, date(2026, 4, 1), None) for p in fv2604_path.rglob("**/UTILMD_AHB*Strom*.xml")]
     if not relevant_files:
         pytest.skip("No UTILMD Strom AHB files found")
-    actual_sqlite_path = create_db_and_populate_with_ahb_view(relevant_files, drop_raw_tables=False)
+    actual_sqlite_path = cached_ahb_db(relevant_files, drop_raw_tables=False)
     _check_uniqueness_of_id_paths(actual_sqlite_path)
 
     # Verify cross-version id_path overlap: most id_paths from FV2510 should also exist in FV2604

--- a/unittests/test_sqlmodels_anwendungshandbuch.py
+++ b/unittests/test_sqlmodels_anwendungshandbuch.py
@@ -19,13 +19,14 @@ from fundamend.models.kommunikationsrichtung import Kommunikationsrichtung
 from fundamend.sqlmodels import AhbHierarchyMaterialized, create_ahb_view, create_db_and_populate_with_ahb_view
 from fundamend.sqlmodels import Anwendungshandbuch as SqlAnwendungshandbuch
 
-from .conftest import cached_ahb_db, is_private_submodule_checked_out
+from .conftest import apply_throwaway_sqlite_pragmas, cached_ahb_db, is_private_submodule_checked_out
 
 
 @pytest.fixture()
 def sqlite_session(tmp_path: Path) -> Generator[Session, None, None]:
     database_path = tmp_path / "test.db"
     engine = create_engine(f"sqlite:///{database_path}")
+    apply_throwaway_sqlite_pragmas(engine)
     SQLModel.metadata.drop_all(engine)
     SQLModel.metadata.create_all(engine)
     with Session(bind=engine) as session:
@@ -94,7 +95,11 @@ def test_sqlmodels_all_anwendungshandbuch(sqlite_session: Session) -> None:
 _Kommunikationsrichtungen = RootModel[list[Kommunikationsrichtung]]
 
 
-def test_sqlmodels_all_anwendungshandbuch_with_ahb_view(sqlite_session: Session) -> None:
+def test_sqlmodels_all_kommunikationsrichtungen_from_submodule() -> None:
+    # Regression test for https://github.com/Hochfrequenz/xml-fundamend-python/issues/173:
+    # every AWF's kommunikationsrichtungen must survive SqlAnwendungshandbuch.from_model unchanged.
+    # This only needs the in-memory conversion; we deliberately do NOT persist the whole corpus to a
+    # database (a single ORM commit of every AHB took ~75 min in CI and asserted nothing extra).
     if not is_private_submodule_checked_out():
         pytest.skip("Skipping test because of missing private submodule")
     private_submodule_root = Path(__file__).parent.parent / "xml-migs-and-ahbs"
@@ -109,7 +114,6 @@ def test_sqlmodels_all_anwendungshandbuch_with_ahb_view(sqlite_session: Session)
             sorted(sql_ahb.anwendungsfaelle, key=lambda _awf: _awf.position or 0),
             strict=False,
         ):
-            # this is for https://github.com/Hochfrequenz/xml-fundamend-python/issues/173
             if awf.kommunikationsrichtungen is not None and any(awf.kommunikationsrichtungen):
                 sql_kommunikationsrichtungen = _Kommunikationsrichtungen.model_validate(
                     sql_awf.kommunikationsrichtungen
@@ -117,9 +121,6 @@ def test_sqlmodels_all_anwendungshandbuch_with_ahb_view(sqlite_session: Session)
                 assert sql_kommunikationsrichtungen == awf.kommunikationsrichtungen
             else:
                 assert sql_awf.kommunikationsrichtungen is None or not any(sql_awf.kommunikationsrichtungen)
-        sqlite_session.add(sql_ahb)
-    sqlite_session.commit()
-    create_ahb_view(session=sqlite_session)
 
 
 @pytest.mark.snapshot

--- a/unittests/test_sqlmodels_expressions_view.py
+++ b/unittests/test_sqlmodels_expressions_view.py
@@ -5,10 +5,9 @@ import pytest
 from sqlmodel import Session, col, create_engine, select
 from syrupy.assertion import SnapshotAssertion
 
-from fundamend.sqlmodels import create_db_and_populate_with_ahb_view
 from fundamend.sqlmodels.expression_view import AhbExpression, create_and_fill_ahb_expression_table
 
-from .conftest import is_private_submodule_checked_out
+from .conftest import cached_ahb_db, is_private_submodule_checked_out
 
 
 @pytest.mark.snapshot
@@ -20,7 +19,7 @@ def test_create_db_and_expressions_view(snapshot: SnapshotAssertion) -> None:
             date(2024, 4, 3),
         )
     ]
-    actual_sqlite_path = create_db_and_populate_with_ahb_view(ahb_files=ahb_paths, drop_raw_tables=True)
+    actual_sqlite_path = cached_ahb_db(ahb_paths, drop_raw_tables=True)
     assert actual_sqlite_path.exists()
     engine = create_engine(f"sqlite:///{actual_sqlite_path}")
     with Session(bind=engine) as session:
@@ -43,7 +42,7 @@ def test_create_expressions_table_from_submodule_with_validity(snapshot: Snapsho
     relevant_files = [
         (p, date(2024, 10, 1), date(2025, 6, 6)) for p in (private_submodule_root / "FV2410").rglob("**/*AHB*.xml")
     ] + [(p, date(2025, 6, 6), None) for p in (private_submodule_root / "FV2504").rglob("**/*AHB*.xml")]
-    actual_sqlite_path = create_db_and_populate_with_ahb_view(relevant_files, drop_raw_tables=True)
+    actual_sqlite_path = cached_ahb_db(relevant_files, drop_raw_tables=True)
     assert actual_sqlite_path.exists()
     engine = create_engine(f"sqlite:///{actual_sqlite_path}")
     with Session(bind=engine) as session:

--- a/unittests/test_sqlmodels_messageimplementationguide.py
+++ b/unittests/test_sqlmodels_messageimplementationguide.py
@@ -12,13 +12,14 @@ from fundamend import MigReader
 from fundamend.models.messageimplementationguide import MessageImplementationGuide as PydanticMessageImplementationGuide
 from fundamend.sqlmodels import MessageImplementationGuide as SqlMessageImplementationGuide
 
-from .conftest import is_private_submodule_checked_out
+from .conftest import apply_throwaway_sqlite_pragmas, is_private_submodule_checked_out
 
 
 @pytest.fixture()
 def sqlite_session(tmp_path: Path) -> Generator[Session, None, None]:
     database_path = tmp_path / "test_mig.db"
     engine = create_engine(f"sqlite:///{database_path}")
+    apply_throwaway_sqlite_pragmas(engine)
     SQLModel.metadata.drop_all(engine)
     SQLModel.metadata.create_all(engine)
     with Session(bind=engine) as session:

--- a/uv.lock
+++ b/uv.lock
@@ -192,6 +192,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/82/32e3bd191d498e64f6f911ad55d14006a0861e54869d2d32452326399e65/coverage-7.15.2-py3-none-any.whl", hash = "sha256:eb6bcae8d1a9d305351ecb108232441d11c5cfe9de840a04388ba5d2db8d735c", size = 213375, upload-time = "2026-07-15T18:56:17.305Z" },
 ]
 
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
 [[package]]
 name = "distlib"
 version = "0.4.3"
@@ -211,6 +216,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1a/ab/99cfdb47005a1c5c8048cd7969f7fba8e7a449de86d26aa7fcb6ff54565c/efoli-2.3.0.tar.gz", hash = "sha256:30b99b3fdf568c336ad955372410b77846154df939a4264ea542c533dc44d713", size = 11391, upload-time = "2026-04-04T11:35:34.04Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/5f/21d964c54215e37528b45eb10cb9fc164d570fec062b2eab8a54ec990cd4/efoli-2.3.0-py3-none-any.whl", hash = "sha256:c61102adc0068d452bf374e587b8b7e365494f7087685dd54ec05dcf177acea3", size = 6713, upload-time = "2026-04-04T11:35:32.461Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -246,6 +260,8 @@ sqlmodels = [
 coverage = [
     { name = "coverage" },
     { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "syrupy" },
 ]
 dev = [
@@ -254,6 +270,8 @@ dev = [
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "syrupy" },
 ]
@@ -265,11 +283,13 @@ spell-check = [
 ]
 tests = [
     { name = "pytest" },
+    { name = "pytest-xdist" },
     { name = "syrupy" },
 ]
 type-check = [
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-xdist" },
     { name = "syrupy" },
 ]
 
@@ -288,6 +308,8 @@ provides-extras = ["ahbicht", "cli", "sqlmodels"]
 coverage = [
     { name = "coverage", specifier = "==7.15.2" },
     { name = "pytest", specifier = "==9.1.1" },
+    { name = "pytest-cov", specifier = "==7.1.0" },
+    { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "syrupy", specifier = "==5.5.3" },
 ]
 dev = [
@@ -296,6 +318,8 @@ dev = [
     { name = "mypy", specifier = "==2.3.0" },
     { name = "pre-commit" },
     { name = "pytest", specifier = "==9.1.1" },
+    { name = "pytest-cov", specifier = "==7.1.0" },
+    { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "ruff", specifier = "==0.16.0" },
     { name = "syrupy", specifier = "==5.5.3" },
 ]
@@ -303,11 +327,13 @@ lint = [{ name = "ruff", specifier = "==0.16.0" }]
 spell-check = [{ name = "codespell", specifier = "==2.4.3" }]
 tests = [
     { name = "pytest", specifier = "==9.1.1" },
+    { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "syrupy", specifier = "==5.5.3" },
 ]
 type-check = [
     { name = "mypy", specifier = "==2.3.0" },
     { name = "pytest", specifier = "==9.1.1" },
+    { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "syrupy", specifier = "==5.5.3" },
 ]
 
@@ -762,6 +788,33 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-discovery"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -962,6 +1015,60 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e7/39/17dde9f0c76cc5abcdeef1b2243791bb850d498f784147b8e460dd23abe8/syrupy-5.5.3.tar.gz", hash = "sha256:fa21e4ae77c89ec5abfca513338d8a7eb916da6618ca0f8db301476e0768e57a", size = 91614, upload-time = "2026-07-11T15:54:31.46Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/f9/617a194c1a4203279998e1859426cf2635042533a99a93d63d3ee1fb967e/syrupy-5.5.3-py3-none-any.whl", hash = "sha256:0b260a0c9dad55e1fb83818973dc36fbc1aea3fd5381592f442a986686c4171a", size = 54959, upload-time = "2026-07-11T15:54:29.836Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -229,11 +229,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.32.0"
+version = "3.32.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c0/80/8232b582c4b318b817cf1274ba74976b07b34d35ef439b3eb948f98645a1/filelock-3.32.0.tar.gz", hash = "sha256:7be2ad23a14607ccc71808e68fe30848aeace7058ace17852f68e2a68e310402", size = 213757, upload-time = "2026-07-21T13:17:42.898Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/57/3ba6e6cb097f85b855b00163d169f35365f44277df044dcf96d55b8f62a3/filelock-3.32.2.tar.gz", hash = "sha256:c33351e1f49cae33414acbc6d56784e6ecee82514ec90795da1161fc4836b5b8", size = 217172, upload-time = "2026-07-29T22:46:04.895Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/79/b4c714bef36bc4ec2beeae1e0c124f0223888cd8c6feb1cdc56038116920/filelock-3.32.0-py3-none-any.whl", hash = "sha256:d396bea984af47333ef05e50eae7eff88c84256de6112aea0ec48a233c064fe3", size = 97732, upload-time = "2026-07-21T13:17:41.55Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/e8/72f8cef9fdfeffe06213fe8508039396ee48daa0e3259457ed766173bfd6/filelock-3.32.2-py3-none-any.whl", hash = "sha256:87dd94cf281e586d135fa51132b8e3d9a598b316e90377a288663c9321036c82", size = 98830, upload-time = "2026-07-29T22:46:03.52Z" },
 ]
 
 [[package]]
@@ -259,6 +259,7 @@ sqlmodels = [
 [package.dev-dependencies]
 coverage = [
     { name = "coverage" },
+    { name = "filelock" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
@@ -267,6 +268,7 @@ coverage = [
 dev = [
     { name = "codespell" },
     { name = "coverage" },
+    { name = "filelock" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -282,11 +284,13 @@ spell-check = [
     { name = "codespell" },
 ]
 tests = [
+    { name = "filelock" },
     { name = "pytest" },
     { name = "pytest-xdist" },
     { name = "syrupy" },
 ]
 type-check = [
+    { name = "filelock" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-xdist" },
@@ -307,6 +311,7 @@ provides-extras = ["ahbicht", "cli", "sqlmodels"]
 [package.metadata.requires-dev]
 coverage = [
     { name = "coverage", specifier = "==7.15.2" },
+    { name = "filelock", specifier = "==3.32.2" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "pytest-xdist", specifier = "==3.8.0" },
@@ -315,6 +320,7 @@ coverage = [
 dev = [
     { name = "codespell", specifier = "==2.4.3" },
     { name = "coverage", specifier = "==7.15.2" },
+    { name = "filelock", specifier = "==3.32.2" },
     { name = "mypy", specifier = "==2.3.0" },
     { name = "pre-commit" },
     { name = "pytest", specifier = "==9.1.1" },
@@ -326,11 +332,13 @@ dev = [
 lint = [{ name = "ruff", specifier = "==0.16.0" }]
 spell-check = [{ name = "codespell", specifier = "==2.4.3" }]
 tests = [
+    { name = "filelock", specifier = "==3.32.2" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "syrupy", specifier = "==5.5.3" },
 ]
 type-check = [
+    { name = "filelock", specifier = "==3.32.2" },
     { name = "mypy", specifier = "==2.3.0" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-xdist", specifier = "==3.8.0" },


### PR DESCRIPTION
Closes #315.

Speeds up the CI test pipeline **without reducing coverage**. Every CI job currently runs the whole (DB-building, ahbicht-parsing) suite single-process; this parallelizes it across cores and trims per-run overhead.

## Changes

- **pytest-xdist**: added to the `tests` group; suite now runs with `-n auto --dist loadfile` (via `addopts`). `--dist loadfile` keeps all tests in a module on one worker, so the expensive `scope="module"` SQLite DB fixtures in `unittests/conftest.py` are built **once per module**, not once per test. Syrupy snapshot tests stay safe because each module owns its own `.ambr` file and CI only *asserts* snapshots (read-only).
- **coverage job → pytest-cov**: `coverage run -m pytest` cannot see xdist worker subprocesses, which would silently collapse the coverage number and break `--cov-fail-under 94`. Switched `coverage.yml` to `pytest --cov=fundamend ... --cov-fail-under=94`, which aggregates worker coverage correctly.
- **Quieter logging**: pinned the `ahbicht`/`lark` expression-parser loggers to `WARNING` in `conftest.py` and set pytest `log_level = WARNING`, removing DEBUG/INFO log-formatting overhead during capture.
- **Latent CI bug fixed**: in `unittests.yml` the typer-install step was gated on `matrix.run_step` (undefined) instead of `matrix.cli`, so `--extra cli` never installed and both matrix legs tested an identical env. Now the `install_typer` leg actually exercises the cli-present path while `skip_typer` keeps covering the import-guard path.

## Considered but dropped

De-duplicating the redundant FV2410+FV2504 DB build in `test_ahb_diff_view_various_pruefis` by reusing the shared fixture: verified locally and it **changed the snapshot** (`changed_columns` gained `bedingung`, because the fixture additionally fills the expression table, which resolves `bedingung` differently). Not coverage-neutral, so reverted. Worth a separate look: that standalone test snapshots a diff built *without* resolved condition-expressions.

## Verification
- `pytest` confirmed running under xdist (`bringing up nodes...`) and passing locally.
- Coverage-neutrality is enforced by the unchanged snapshots + the `--cov-fail-under=94` gate — this PR's CI run is the real measurement of both the wall-clock saving and that coverage holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)