### PR TITLE
design: opt-in, local-only test database cache

### DIFF
--- a/docs/superpowers/specs/2026-08-10-local-db-cache-opt-in-design.md
+++ b/docs/superpowers/specs/2026-08-10-local-db-cache-opt-in-design.md
@@ -1,0 +1,147 @@
+# Opt-in local test database cache
+
+**Date:** 2026-08-10
+**Status:** Approved (design), pending implementation
+**Depends on:** PR #321 (`refactor(tests): remove the SQLite database cache, keep xdist`)
+
+## Problem
+
+Building the SQLite test databases from the `xml-migs-and-ahbs` submodule dominates the test
+runtime. PR #317 solved this with an on-disk cache, but keyed each entry only on
+`_CACHE_VERSION`, the recipe name and the input XML (paths, validity dates, contents). The key did
+not cover the `fundamend` code that builds the database, nor the versions of the dependencies
+involved. A change to a reader, a view definition or the expression evaluation therefore left the
+key unchanged, and the suite asserted against a database built by the previous version of the code.
+PR #321 removed that cache.
+
+Local development still wants the speed. CI still wants to be pedantic: every run must exercise the
+code under test, with no reuse of anything built by earlier code.
+
+## Goals
+
+- Fast, repeated local test runs for developers who ask for them.
+- CI always builds every database from scratch, with no way to opt in by accident.
+- No manual invalidation step. If a cached database could differ from a fresh build, the cache must
+  miss on its own.
+- The mechanism must be explainable in a few lines of README.
+
+## Non-goals
+
+- Sharing caches between machines, or persisting them across CI runs.
+- Caching anything other than the built SQLite databases.
+- Reducing the cold runtime of the suite. That is worth doing, but it is separate work (the
+  duplicated FV2410+FV2504 build across the two diff-view modules is the obvious first candidate).
+
+## Design
+
+### Enabling
+
+`unittests/_db_cache.py` reads the environment variable `FUNDAMEND_TEST_DB_CACHE`. If it is unset or
+empty, `cached_db(key, builder)` calls `builder()` and returns its result: no cache directory is
+created, no lock is taken, no file is copied. The cache is not merely "off" — the code path does not
+execute.
+
+CI workflows are not changed and set nothing. A cached run therefore cannot produce a green CI
+result. Enabling is a deliberate local act:
+
+```bash
+export FUNDAMEND_TEST_DB_CACHE=1
+uv run pytest
+```
+
+### The cache key
+
+`fingerprint(recipe, files)` hashes, in this order:
+
+1. the recipe name (which build variant: raw tables only, with diff views, ...)
+2. for each input file, sorted: its path, `gueltig_von`, `gueltig_bis` and its contents
+3. the **code fingerprint** (below)
+
+The code fingerprint is a hash over everything that determines what a built database contains:
+
+- every `src/fundamend/**/*.py` file — builders, readers, view definitions
+- `uv.lock` — pins `ahbicht` and `lark`, which fill `ahb_expressions`
+- `unittests/conftest.py` — `_build_ahb_db_with_diff_view` decides which views a fixture's database
+  receives
+
+It is computed once per process and memoized; the cost is one hash over a few dozen small files per
+test run.
+
+`_CACHE_VERSION` is deliberately **not** reintroduced. The code fingerprint subsumes it: any change
+to how a database is built already changes the key. There is no manual bump to remember and no
+invariant a contributor can violate by forgetting something.
+
+The known limit of this approach, accepted explicitly: the fingerprint covers the declared
+environment, not the realised one. A different Python patch version or a differently-built native
+wheel with an identical `uv.lock` produces the same key. This is acceptable because the cache is
+local-only and a developer's environment is stable between runs; it would not be acceptable for a
+cache shared across machines, which is why this design does not have one.
+
+### Scope of caching
+
+All existing call sites route through the cache again: the `cached_ahb_db` / `cached_mig_db` helpers
+in `unittests/conftest.py`, their 13 call sites across `test_ahb_formatversion_diff_view.py`,
+`test_mig_views.py`, `test_sqlmodels_anwendungshandbuch.py` and
+`test_sqlmodels_expressions_view.py`, plus the two module-scoped fixtures
+(`session_fv2410_fv2504_with_diff_view`, `session_fv2510_fv2604_mscons_with_diff_view`).
+
+Uniform coverage is chosen over a curated subset because the rule stays one sentence: every
+submodule-scale build goes through the cache, and the cache is a no-op unless enabled. A partial
+list would need maintaining and would invite the question "why is this one not cached?".
+
+Cheap example-file tests and builder-error-path tests continue to build directly, as they do today.
+
+### Storage and failure handling
+
+Cache entries live in `.pytest_db_cache/` (gitignored again), one `<key>.sqlite` per entry. A
+`FileLock` guards cold population so concurrent pytest-xdist workers build an entry exactly once;
+`filelock` returns as a `tests` dependency. Each caller receives its own copy of the cached file, so
+no two sessions share a database file.
+
+The cache must never be able to break a test run. If the cache directory cannot be created or
+written, or a cached file cannot be read, `cached_db` emits a warning and falls back to calling
+`builder()`. Entries are never evicted automatically; reclaiming space means deleting the directory,
+which is safe at any time.
+
+## Tests
+
+New tests in `unittests/test_db_cache.py`. All are fast and require no submodule.
+
+| Test | Asserts |
+|------|---------|
+| disabled by default | with the env var unset, `builder` runs on every call and no cache directory is created |
+| enabled, cold then warm | with the env var set, two requests for the same key call `builder` once and return equal database contents |
+| fingerprint is stable | identical inputs produce an identical fingerprint |
+| source change invalidates | modifying a file under a stubbed source root changes the fingerprint |
+| lock file change invalidates | modifying the stubbed `uv.lock` changes the fingerprint |
+| conftest change invalidates | modifying the stubbed `conftest.py` changes the fingerprint |
+| input change invalidates | changing an input file's contents, path or validity dates changes the fingerprint |
+| unwritable cache falls back | with the cache directory made unusable, the call still returns a working database |
+
+The invalidation tests are the regression tests for the defect that motivated PR #321: they fail if
+someone later narrows the key back to the input data.
+
+To keep them fast and hermetic, the paths that feed the code fingerprint are injectable — the
+production default points at the real `src/fundamend`, `uv.lock` and `unittests/conftest.py`, and the
+tests pass temporary directories instead.
+
+## Documentation
+
+The README's testing section gains a short passage (target: ~8 lines) covering how to enable the
+cache, that everything relevant invalidates automatically, and that CI never uses it. PR #321
+replaced the old cache chapter with a note saying the databases are deliberately not cached; that
+note is amended here to "not cached in CI, opt-in locally". Shipping the code without amending it
+would leave the repository contradicting itself.
+
+If the passage cannot be kept short, the design is wrong and should be reconsidered rather than
+documented at length.
+
+## Delivery
+
+A stacked pull request: branch `local-db-cache-opt-in` off `remove-test-db-cache`, with the PR based
+on `remove-test-db-cache` so reviewers see only the incremental diff.
+
+Because the repository is squash-merge-only, `a952c6e` will not become an ancestor of `main` when
+#321 merges. After that merge the stacked branch needs
+`git rebase --onto main remove-test-db-cache local-db-cache-opt-in` and a force-push with lease;
+GitHub's automatic retarget alone would show a doubled diff.

--- a/docs/superpowers/specs/2026-08-10-local-db-cache-opt-in-design.md
+++ b/docs/superpowers/specs/2026-08-10-local-db-cache-opt-in-design.md
@@ -1,8 +1,9 @@
 # Opt-in local test database cache
 
 **Date:** 2026-08-10
-**Status:** Approved (design), pending implementation
-**Depends on:** PR #321 (`refactor(tests): remove the SQLite database cache, keep xdist`)
+**Status:** Design reviewed (three rounds); awaiting sign-off before implementation
+**Builds on:** PR #321 (`refactor(tests): remove the SQLite database cache, keep xdist`), merged as
+`bab5b4f`
 
 ## Problem
 
@@ -139,6 +140,12 @@ For the same reason `cached_db()` takes the paths object as an optional keyword 
 it receives an already-computed key and never fingerprints anything: it needs the cache directory
 from it. Callers that do not pass one get the production default.
 
+Publication into the cache stays **atomic**, as it was before removal: the built database is copied
+to a temporary name inside the cache directory and then `Path.replace()`d into place. A reader must
+never be able to observe a half-written entry. This matters more than the lock does — the lock only
+serialises concurrent xdist workers within one run, whereas an interrupted run (Ctrl-C, OOM kill)
+would otherwise leave a truncated `.sqlite` behind that every later run happily reuses.
+
 The cache must never be able to break a test run. If the cache directory cannot be created or
 written, or a cached file cannot be read, `cached_db` emits a warning and falls back to calling
 `builder()`. Entries are never evicted automatically; reclaiming space means deleting the directory,
@@ -192,10 +199,14 @@ back. Check before pushing rather than spending a CI round-trip on it.
 
 ## Delivery
 
-A stacked pull request: branch `local-db-cache-opt-in` off `remove-test-db-cache`, with the PR based
-on `remove-test-db-cache` so reviewers see only the incremental diff.
+This work lives on branch `local-db-cache-opt-in`, opened as PR #323 with this document as its only
+content so the design can be argued with before it is built. Implementation commits follow on the
+same branch once the design is signed off.
 
-Because the repository is squash-merge-only, `a952c6e` will not become an ancestor of `main` when
-#321 merges. After that merge the stacked branch needs
-`git rebase --onto main remove-test-db-cache local-db-cache-opt-in` and a force-push with lease;
-GitHub's automatic retarget alone would show a doubled diff.
+The branch was originally stacked on `remove-test-db-cache`. That branch has since been squash-merged
+as `bab5b4f`, and because the repository is squash-merge-only the pre-merge commits never became
+ancestors of `main`; the branch was therefore rebased with
+`git rebase --onto origin/main remove-test-db-cache local-db-cache-opt-in` and force-pushed with
+lease. It now shows a clean single-file diff against `main`. This is recorded because the same
+manoeuvre will be needed for any future branch stacked on an unmerged PR in this repository —
+GitHub's automatic retarget on its own produces a doubled diff.

--- a/docs/superpowers/specs/2026-08-10-local-db-cache-opt-in-design.md
+++ b/docs/superpowers/specs/2026-08-10-local-db-cache-opt-in-design.md
@@ -36,10 +36,11 @@ code under test, with no reuse of anything built by earlier code.
 
 ### Enabling
 
-`unittests/_db_cache.py` reads the environment variable `FUNDAMEND_TEST_DB_CACHE`. If it is unset or
-empty, `cached_db(key, builder)` calls `builder()` and returns its result: no cache directory is
-created, no lock is taken, no file is copied. The cache is not merely "off" — the code path does not
-execute.
+`unittests/_db_cache.py` reads the environment variable `FUNDAMEND_TEST_DB_CACHE`. The cache is
+enabled only when its value is one of `1`, `true`, `yes` (case-insensitive); anything else,
+including unset, empty, `0` and `false`, disables it. When disabled, `cached_db(key, builder)` calls
+`builder()` and returns its result: no cache directory is created, no lock is taken, no file is
+copied. The cache is not merely "off" — the code path does not execute.
 
 CI workflows are not changed and set nothing. A cached run therefore cannot produce a green CI
 result. Enabling is a deliberate local act:
@@ -53,19 +54,29 @@ uv run pytest
 
 `fingerprint(recipe, files)` hashes, in this order:
 
-1. the recipe name (which build variant: raw tables only, with diff views, ...)
+1. the recipe name. This must continue to encode the builder flags as it did before removal —
+   `cached_ahb_db` used `f"ahb_raw_drop{int(drop_raw_tables)}"` — because `drop_raw_tables` changes
+   the resulting schema for otherwise identical inputs
 2. for each input file, sorted: its path, `gueltig_von`, `gueltig_bis` and its contents
 3. the **code fingerprint** (below)
 
 The code fingerprint is a hash over everything that determines what a built database contains:
 
-- every `src/fundamend/**/*.py` file — builders, readers, view definitions
+- **every file under `src/fundamend/`**, not just `*.py`. The package ships six `.sql` files
+  (`materialize_ahb_view.sql`, `materialize_mig_view.sql`, `create_ahbtabellen_view.sql`,
+  `create_ahb_formatversion_diff_view.sql`, `create_ahb_pruefi_diff_view.sql`,
+  `create_mig_diff_view.sql`) which are read at runtime and executed straight into the database.
+  Editing a view's SQL is the most likely way to change what a database contains, so a `*.py`-only
+  glob would reproduce exactly the defect this design exists to prevent. `__pycache__` and `*.pyc`
+  are excluded; everything else under the package directory is hashed by relative path and content.
 - `uv.lock` — pins `ahbicht` and `lark`, which fill `ahb_expressions`
 - `unittests/conftest.py` — `_build_ahb_db_with_diff_view` decides which views a fixture's database
   receives
 
-It is computed once per process and memoized; the cost is one hash over a few dozen small files per
-test run.
+The result is memoized **keyed on the (source root, lock path, conftest path) triple**, not once per
+process. A plain process-level memo would break the invalidation tests, which compute fingerprints
+from several different stubbed roots within a single pytest process. In a normal run the triple is
+constant, so the hash is still computed only once: one pass over a few dozen small files.
 
 `_CACHE_VERSION` is deliberately **not** reintroduced. The code fingerprint subsumes it: any change
 to how a database is built already changes the key. There is no manual bump to remember and no
@@ -110,20 +121,29 @@ New tests in `unittests/test_db_cache.py`. All are fast and require no submodule
 | Test | Asserts |
 |------|---------|
 | disabled by default | with the env var unset, `builder` runs on every call and no cache directory is created |
+| `0`/`false` also disable | the documented disabling values behave like unset |
 | enabled, cold then warm | with the env var set, two requests for the same key call `builder` once and return equal database contents |
 | fingerprint is stable | identical inputs produce an identical fingerprint |
-| source change invalidates | modifying a file under a stubbed source root changes the fingerprint |
+| `.py` change invalidates | modifying a Python file under a stubbed source root changes the fingerprint |
+| **`.sql` change invalidates** | modifying a `.sql` file under a stubbed source root changes the fingerprint |
 | lock file change invalidates | modifying the stubbed `uv.lock` changes the fingerprint |
 | conftest change invalidates | modifying the stubbed `conftest.py` changes the fingerprint |
 | input change invalidates | changing an input file's contents, path or validity dates changes the fingerprint |
-| unwritable cache falls back | with the cache directory made unusable, the call still returns a working database |
+| recipe change invalidates | the same inputs under a different recipe (e.g. `drop_raw_tables`) produce a different fingerprint |
+| unusable cache falls back | when the cache directory cannot be created, the call still returns a working database |
 
 The invalidation tests are the regression tests for the defect that motivated PR #321: they fail if
 someone later narrows the key back to the input data.
 
-To keep them fast and hermetic, the paths that feed the code fingerprint are injectable — the
-production default points at the real `src/fundamend`, `uv.lock` and `unittests/conftest.py`, and the
-tests pass temporary directories instead.
+To keep them fast and hermetic, the paths that feed the code fingerprint are injectable as an
+explicit parameter object (source root, lock path, conftest path) with a module-level production
+default pointing at the real `src/fundamend`, `uv.lock` and `unittests/conftest.py`. Tests pass
+temporary directories instead. `fingerprint()` and `cached_db()` take it as an optional keyword
+argument, so the 13 call sites and both fixtures are unaffected.
+
+The "unusable cache" test must be cross-platform: read-only directories do not reliably block writes
+on Windows, which is a primary development platform here. The test therefore points the cache
+directory at a path where a *file* already exists, so directory creation fails on every OS.
 
 ## Documentation
 
@@ -135,6 +155,10 @@ would leave the repository contradicting itself.
 
 If the passage cannot be kept short, the design is wrong and should be reconsidered rather than
 documented at length.
+
+CI runs `codespell --ignore-words=domain-specific-terms.txt` over `README.md`. PR #321 removed four
+German words from that list along with the old cache chapter; the new passage may need some of them
+back. Check before pushing rather than spending a CI round-trip on it.
 
 ## Delivery
 

--- a/docs/superpowers/specs/2026-08-10-local-db-cache-opt-in-design.md
+++ b/docs/superpowers/specs/2026-08-10-local-db-cache-opt-in-design.md
@@ -69,14 +69,21 @@ The code fingerprint is a hash over everything that determines what a built data
   Editing a view's SQL is the most likely way to change what a database contains, so a `*.py`-only
   glob would reproduce exactly the defect this design exists to prevent. `__pycache__` and `*.pyc`
   are excluded; everything else under the package directory is hashed by relative path and content.
-- `uv.lock` — pins `ahbicht` and `lark`, which fill `ahb_expressions`
-- `unittests/conftest.py` — `_build_ahb_db_with_diff_view` decides which views a fixture's database
-  receives
+- `uv.lock` — pins `ahbicht` and `lark`, which fill `ahb_expressions`. It also pins `ruff`, `mypy`
+  and `pytest`, so a lint-tool bump invalidates every entry too. That is wasteful but never wrong,
+  and it is the price of a rule that needs no exceptions list.
+- **every `unittests/*.py`** (top level, `__pycache__` excluded), not only `conftest.py`.
+  `_build_ahb_db_with_diff_view` lives in `conftest.py` today, but hashing the directory removes a
+  silent failure mode: the day builder logic moves into a `unittests/_helpers.py`, a
+  `conftest.py`-only rule would stop covering it and no test would fail. The cost is a chattier
+  cache — editing any test file invalidates local entries — which is cheap for a local-only cache
+  and is the same one-sentence rule as the `src/fundamend/` one.
 
-The result is memoized **keyed on the (source root, lock path, conftest path) triple**, not once per
-process. A plain process-level memo would break the invalidation tests, which compute fingerprints
-from several different stubbed roots within a single pytest process. In a normal run the triple is
-constant, so the hash is still computed only once: one pass over a few dozen small files.
+The result is memoized **keyed on the paths object** (source root, lock path, unittests root), not
+once per process. A plain process-level memo would break the invalidation tests, which compute
+fingerprints from several different stubbed roots within a single pytest process. In a normal run
+the object is constant, so the hash is still computed only once: one pass over a few dozen small
+files.
 
 `_CACHE_VERSION` is deliberately **not** reintroduced. The code fingerprint subsumes it: any change
 to how a database is built already changes the key. There is no manual bump to remember and no
@@ -87,6 +94,12 @@ environment, not the realised one. A different Python patch version or a differe
 wheel with an identical `uv.lock` produces the same key. This is acceptable because the cache is
 local-only and a developer's environment is stable between runs; it would not be acceptable for a
 cache shared across machines, which is why this design does not have one.
+
+A cached database is **equivalent to** a fresh build, not byte-identical with one: primary keys come
+from `uuid.uuid4()` in the SQLModel tables and from `hex(randomblob(16))` in
+`materialize_ahb_view.sql` and `materialize_mig_view.sql`. "Deterministic builders" holds only up to
+those ids. No test may assert on freshly generated id values, and none does today — the existing
+snapshot tests strip the guid columns before comparing.
 
 ### Scope of caching
 
@@ -107,7 +120,20 @@ Cheap example-file tests and builder-error-path tests continue to build directly
 Cache entries live in `.pytest_db_cache/` (gitignored again), one `<key>.sqlite` per entry. A
 `FileLock` guards cold population so concurrent pytest-xdist workers build an entry exactly once;
 `filelock` returns as a `tests` dependency. Each caller receives its own copy of the cached file, so
-no two sessions share a database file.
+no two sessions share a database file. Those per-caller copies are `NamedTemporaryFile(delete=False)`
+as before and are left for the OS to reap — the tests already treat the returned path as a throwaway
+file, and adding lifecycle management would be unrequested complexity.
+
+**The cache directory is part of the injectable paths object**, as a fourth field alongside the
+source root, lock path and unittests root, defaulting to `<repo>/.pytest_db_cache`. Four of the
+tests below need to control it — "no directory is created", the disabling values, the cold/warm
+sequence, and the fallback case. Without injection those tests would read and write the developer's
+real cache: the cold/warm test would pollute it, and "no directory is created" would fail on any
+machine where an earlier opt-in run had left the directory behind.
+
+For the same reason `cached_db()` takes the paths object as an optional keyword argument even though
+it receives an already-computed key and never fingerprints anything: it needs the cache directory
+from it. Callers that do not pass one get the production default.
 
 The cache must never be able to break a test run. If the cache directory cannot be created or
 written, or a cached file cannot be read, `cached_db` emits a warning and falls back to calling
@@ -127,7 +153,7 @@ New tests in `unittests/test_db_cache.py`. All are fast and require no submodule
 | `.py` change invalidates | modifying a Python file under a stubbed source root changes the fingerprint |
 | **`.sql` change invalidates** | modifying a `.sql` file under a stubbed source root changes the fingerprint |
 | lock file change invalidates | modifying the stubbed `uv.lock` changes the fingerprint |
-| conftest change invalidates | modifying the stubbed `conftest.py` changes the fingerprint |
+| unittests change invalidates | modifying a file under the stubbed unittests root changes the fingerprint |
 | input change invalidates | changing an input file's contents, path or validity dates changes the fingerprint |
 | recipe change invalidates | the same inputs under a different recipe (e.g. `drop_raw_tables`) produce a different fingerprint |
 | unusable cache falls back | when the cache directory cannot be created, the call still returns a working database |
@@ -135,11 +161,11 @@ New tests in `unittests/test_db_cache.py`. All are fast and require no submodule
 The invalidation tests are the regression tests for the defect that motivated PR #321: they fail if
 someone later narrows the key back to the input data.
 
-To keep them fast and hermetic, the paths that feed the code fingerprint are injectable as an
-explicit parameter object (source root, lock path, conftest path) with a module-level production
-default pointing at the real `src/fundamend`, `uv.lock` and `unittests/conftest.py`. Tests pass
-temporary directories instead. `fingerprint()` and `cached_db()` take it as an optional keyword
-argument, so the 13 call sites and both fixtures are unaffected.
+To keep them fast and hermetic, every path the module touches is injectable as one explicit
+parameter object — source root, lock path, unittests root, cache directory — with a module-level
+production default pointing at the real `src/fundamend`, `uv.lock`, `unittests/` and
+`.pytest_db_cache/`. Tests pass temporary directories instead. `fingerprint()` and `cached_db()`
+take it as an optional keyword argument, so the 13 call sites and both fixtures are unaffected.
 
 The "unusable cache" test must be cross-platform: read-only directories do not reliably block writes
 on Windows, which is a primary development platform here. The test therefore points the cache

--- a/docs/superpowers/specs/2026-08-10-local-db-cache-opt-in-design.md
+++ b/docs/superpowers/specs/2026-08-10-local-db-cache-opt-in-design.md
@@ -38,7 +38,8 @@ code under test, with no reuse of anything built by earlier code.
 
 `unittests/_db_cache.py` reads the environment variable `FUNDAMEND_TEST_DB_CACHE`. The cache is
 enabled only when its value is one of `1`, `true`, `yes` (case-insensitive); anything else,
-including unset, empty, `0` and `false`, disables it. When disabled, `cached_db(key, builder)` calls
+including unset, empty, `0` and `false`, disables it. The variable is **evaluated on each
+`cached_db()` call, not once at import**, so tests can flip it with `monkeypatch.setenv`. When disabled, `cached_db(key, builder)` calls
 `builder()` and returns its result: no cache directory is created, no lock is taken, no file is
 copied. The cache is not merely "off" — the code path does not execute.
 
@@ -72,14 +73,17 @@ The code fingerprint is a hash over everything that determines what a built data
 - `uv.lock` — pins `ahbicht` and `lark`, which fill `ahb_expressions`. It also pins `ruff`, `mypy`
   and `pytest`, so a lint-tool bump invalidates every entry too. That is wasteful but never wrong,
   and it is the price of a rule that needs no exceptions list.
-- **every `unittests/*.py`** (top level, `__pycache__` excluded), not only `conftest.py`.
+- **every `unittests/**/*.py`** (recursive; `__pycache__`, `__snapshots__` and `example_files`
+  excluded), not only `conftest.py`.
   `_build_ahb_db_with_diff_view` lives in `conftest.py` today, but hashing the directory removes a
-  silent failure mode: the day builder logic moves into a `unittests/_helpers.py`, a
-  `conftest.py`-only rule would stop covering it and no test would fail. The cost is a chattier
-  cache — editing any test file invalidates local entries — which is cheap for a local-only cache
-  and is the same one-sentence rule as the `src/fundamend/` one.
+  silent failure mode: the day builder logic moves into a `unittests/_helpers.py` — or a
+  `unittests/helpers/build.py` — a `conftest.py`-only or top-level-only rule would stop covering it
+  and no test would fail. Recursing keeps the rule as airtight as the `src/fundamend/` one. The cost
+  is a chattier cache — editing any test file invalidates local entries — which is cheap for a
+  local-only cache.
 
-The result is memoized **keyed on the paths object** (source root, lock path, unittests root), not
+The result is memoized **keyed on the paths object** (source root, lock path, unittests root, cache
+directory), which is therefore a frozen dataclass so it can serve as a dict key. It is not memoized
 once per process. A plain process-level memo would break the invalidation tests, which compute
 fingerprints from several different stubbed roots within a single pytest process. In a normal run
 the object is constant, so the hash is still computed only once: one pass over a few dozen small
@@ -150,10 +154,10 @@ New tests in `unittests/test_db_cache.py`. All are fast and require no submodule
 | `0`/`false` also disable | the documented disabling values behave like unset |
 | enabled, cold then warm | with the env var set, two requests for the same key call `builder` once and return equal database contents |
 | fingerprint is stable | identical inputs produce an identical fingerprint |
-| `.py` change invalidates | modifying a Python file under a stubbed source root changes the fingerprint |
-| **`.sql` change invalidates** | modifying a `.sql` file under a stubbed source root changes the fingerprint |
-| lock file change invalidates | modifying the stubbed `uv.lock` changes the fingerprint |
-| unittests change invalidates | modifying a file under the stubbed unittests root changes the fingerprint |
+| `.py` change invalidates | two stubbed source roots differing only in a `.py` file produce different fingerprints |
+| **`.sql` change invalidates** | two stubbed source roots differing only in a `.sql` file produce different fingerprints |
+| lock file change invalidates | two stubbed `uv.lock` files differing in content produce different fingerprints |
+| unittests change invalidates | two stubbed unittests roots differing only in one file produce different fingerprints |
 | input change invalidates | changing an input file's contents, path or validity dates changes the fingerprint |
 | recipe change invalidates | the same inputs under a different recipe (e.g. `drop_raw_tables`) produce a different fingerprint |
 | unusable cache falls back | when the cache directory cannot be created, the call still returns a working database |

--- a/docs/superpowers/specs/2026-08-10-local-db-cache-opt-in-design.md
+++ b/docs/superpowers/specs/2026-08-10-local-db-cache-opt-in-design.md
@@ -59,7 +59,15 @@ uv run pytest
 1. the recipe name. This must continue to encode the builder flags as it did before removal —
    `cached_ahb_db` used `f"ahb_raw_drop{int(drop_raw_tables)}"` — because `drop_raw_tables` changes
    the resulting schema for otherwise identical inputs
-2. for each input file, sorted: its path, `gueltig_von`, `gueltig_bis` and its contents
+2. for each input file, sorted: its path, `gueltig_von`, `gueltig_bis` and its contents. The path is
+   normalised to a **repo-relative POSIX path** (`PurePath.relative_to(repo_root).as_posix()`) before
+   hashing. The pre-removal implementation hashed `str(path)`, i.e. an absolute, OS-flavoured path,
+   which makes the fingerprint depend on where the checkout happens to live and on the path
+   separator. Normalising means moving or re-cloning a checkout does not throw away the whole cache,
+   and two developers on different platforms compute the same key for the same file. The relative
+   path is still part of the identity, so two distinct files with identical contents remain
+   distinguishable. An input outside the repository root (not something the suite does today) falls
+   back to the absolute POSIX path.
 3. the **code fingerprint** (below)
 
 The code fingerprint is a hash over everything that determines what a built database contains:
@@ -126,8 +134,12 @@ Cache entries live in `.pytest_db_cache/` (gitignored again), one `<key>.sqlite`
 `FileLock` guards cold population so concurrent pytest-xdist workers build an entry exactly once;
 `filelock` returns as a `tests` dependency. Each caller receives its own copy of the cached file, so
 no two sessions share a database file. Those per-caller copies are `NamedTemporaryFile(delete=False)`
-as before and are left for the OS to reap — the tests already treat the returned path as a throwaway
-file, and adding lifecycle management would be unrequested complexity.
+as before. Cleanup of them is **best-effort at most**: nothing deletes them, and on Windows in
+particular the system temp directory is not reliably swept, so they accumulate until the OS or the
+developer clears it. That is the pre-existing behaviour and this design does not change it, but it
+should not be described as the OS reaping them. Each copy is roughly the size of one built database,
+so a developer running the suite repeatedly with the cache on will want to clear their temp directory
+occasionally. Adding lifecycle management is possible but out of scope here.
 
 **The cache directory is part of the injectable paths object**, as a fourth field alongside the
 source root, lock path and unittests root, defaulting to `<repo>/.pytest_db_cache`. Four of the
@@ -206,7 +218,7 @@ same branch once the design is signed off.
 The branch was originally stacked on `remove-test-db-cache`. That branch has since been squash-merged
 as `bab5b4f`, and because the repository is squash-merge-only the pre-merge commits never became
 ancestors of `main`; the branch was therefore rebased with
-`git rebase --onto origin/main remove-test-db-cache local-db-cache-opt-in` and force-pushed with
-lease. It now shows a clean single-file diff against `main`. This is recorded because the same
+`git rebase --onto origin/main remove-test-db-cache local-db-cache-opt-in` followed by
+`git push --force-with-lease origin local-db-cache-opt-in`. It now shows a clean single-file diff against `main`. This is recorded because the same
 manoeuvre will be needed for any future branch stacked on an unmerged PR in this repository —
 GitHub's automatic retarget on its own produces a doubled diff.


### PR DESCRIPTION
**Design only — no implementation yet.** This PR exists so the design can be argued with before it is built. It adds one file: `docs/superpowers/specs/2026-08-10-local-db-cache-opt-in-design.md`.

## Context

#317 added an on-disk cache of the built SQLite test databases. #321 removed it, because the cache key covered the input XML but not the `fundamend` code that builds the databases — so a code change could be served a database built by the previous version of the code, and the suite would go green without having seen the change.

Removing it cost real time. Measured on #321: the slowest `pytest` leg ran **1 h 43 min**, coverage **1 h 30 min**, and since the eight matrix legs run concurrently the aggregate is roughly **12 hours of runner time per push**.

hf-krechan asked whether we can have the speed locally while CI stays pedantic. This is the design for that.

## The proposal in three points

1. **Opt-in, off by default.** `unittests/_db_cache.py` checks `FUNDAMEND_TEST_DB_CACHE`. Unset (or `0`/`false`) and `cached_db()` simply calls the builder — no cache directory, no lock, no copy. CI workflows are not changed and set nothing, so a cached run cannot produce a green CI result.

2. **The key covers the code, not just the data.** The fingerprint hashes every file under `src/fundamend/` — including the six `.sql` view definitions that are read from disk at runtime — plus `uv.lock` and `unittests/**/*.py`, on top of the input XML paths/dates/contents. Any change to how a database is built already changes the key.

3. **No `_CACHE_VERSION`.** The old design required a manual bump whenever the builder changed. It reached `v3` three days after landing. Point 2 makes the bump unnecessary: there is no invariant left for a contributor to violate by forgetting.

## Two choices I made unilaterally, and would like challenged

- **`uv.lock` is in the key.** It pins `ahbicht`/`lark`, which fill `ahb_expressions` — but it also pins `ruff`, `mypy` and `pytest`, so a lint-tool bump invalidates every local entry. Wasteful, never wrong. The alternative is an allowlist of "real" dependencies, which is an exceptions list someone has to maintain.
- **`unittests/**/*.py` is in the key**, not just `conftest.py`. So editing any test file invalidates your local cache. The gain is that builder logic moving out of `conftest.py` into a helper module cannot silently escape the fingerprint.

Both trade cache hit rate for a rule that needs no exceptions. If the day-to-day chattiness is worse than I think, the person who will actually use this daily should say so now.

## Review history

Three review rounds against the spec, two of which found genuine defects in the design:

- Round 1 caught that hashing `src/fundamend/**/*.py` would miss the six runtime-loaded `.sql` files — editing a view's SQL is the most likely way to change a database's content, so that would have rebuilt #321's bug in narrower form.
- Round 2 caught that the cache directory was not injectable although four of the planned tests need to control it, which would have had those tests reading and writing the developer's real cache.
- Round 3 approved.

## What happens next

If the design holds up, implementation follows on this branch: the `_db_cache.py` rewrite, a new `unittests/test_db_cache.py` (whose invalidation tests are the regression tests for #321's defect), `filelock` and the `.gitignore` entry back, and a short README passage amending #321's "we deliberately do not cache" to "not in CI, opt-in locally".
