### PR TITLE
feat(tests): opt-in local database cache that invalidates itself

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+.pytest_db_cache/
 
 # Translations
 *.mo

--- a/README.md
+++ b/README.md
@@ -391,12 +391,21 @@ Ein einzelner Worker lässt sich mit `uv run pytest -n0` erzwingen (z.B. zum Deb
 Viele Tests bauen SQLite-Datenbanken aus den XML-Dateien des privaten Submoduls `xml-migs-and-ahbs`.
 Das ist teuer (XML-Parsing + `ahbicht`-Ausdrucksauswertung), und die Testlaufzeit wird davon dominiert.
 
-Diese Datenbanken werden bewusst **nicht** zwischengespeichert. Ein Cache müsste nicht nur die
-Eingabedaten (Submodul-XML), sondern auch den Code, der die Datenbank baut, und die Versionen der
-Abhängigkeiten (z.B. `ahbicht`) im Schlüssel abbilden. Tut er das nicht, liefert er nach einer
-Code-Änderung eine Datenbank aus, die noch mit dem *alten* Code gebaut wurde – die Tests sind dann grün,
-obwohl sie die Änderung nie gesehen haben. Wir zahlen lieber die Rechenzeit als dieses Risiko.
-Wer die Tests beschleunigen will, sollte sie schneller machen, nicht ihr Ergebnis konservieren.
+In der CI werden diese Datenbanken bewusst **nie** zwischengespeichert: jeder CI-Lauf baut alles neu
+und prüft damit garantiert den Code des jeweiligen Commits.
+
+Lokal kann man den Cache einschalten:
+
+```bash
+export FUNDAMEND_TEST_DB_CACHE=1   # aktiviert wird nur bei 1/true/yes
+uv run pytest
+```
+
+Der Schlüssel eines Eintrags umfasst nicht nur die Eingabe-XML, sondern auch alles, was bestimmt,
+*wie* gebaut wird: sämtliche Dateien unter `src/fundamend` (inklusive der `.sql`-View-Definitionen),
+`uv.lock` und die Testquellen. Jede relevante Änderung invalidiert den Cache also von selbst – es gibt
+keine Versionsnummer, die von Hand hochgezählt werden muss. Der Cache liegt unter `.pytest_db_cache/`
+und kann jederzeit gelöscht werden.
 
 ## Hochfrequenz
 Die [Hochfrequenz Unternehmensberatung GmbH](https://www.hochfrequenz.de) ist eine Beratung für Energieversorger im deutschsprachigen Raum.

--- a/README.md
+++ b/README.md
@@ -391,21 +391,19 @@ Ein einzelner Worker lässt sich mit `uv run pytest -n0` erzwingen (z.B. zum Deb
 Viele Tests bauen SQLite-Datenbanken aus den XML-Dateien des privaten Submoduls `xml-migs-and-ahbs`.
 Das ist teuer (XML-Parsing + `ahbicht`-Ausdrucksauswertung), und die Testlaufzeit wird davon dominiert.
 
-In der CI werden diese Datenbanken bewusst **nie** zwischengespeichert: jeder CI-Lauf baut alles neu
-und prüft damit garantiert den Code des jeweiligen Commits.
-
-Lokal kann man den Cache einschalten:
+In der CI werden sie bewusst **nie** zwischengespeichert; lokal kann man den Cache mit
+`FUNDAMEND_TEST_DB_CACHE=1` (nur `1`/`true`/`yes` aktivieren ihn) einschalten:
 
 ```bash
-export FUNDAMEND_TEST_DB_CACHE=1   # aktiviert wird nur bei 1/true/yes
-uv run pytest
+FUNDAMEND_TEST_DB_CACHE=1 uv run pytest
 ```
 
-Der Schlüssel eines Eintrags umfasst nicht nur die Eingabe-XML, sondern auch alles, was bestimmt,
-*wie* gebaut wird: sämtliche Dateien unter `src/fundamend` (inklusive der `.sql`-View-Definitionen),
-`uv.lock` und die Testquellen. Jede relevante Änderung invalidiert den Cache also von selbst – es gibt
-keine Versionsnummer, die von Hand hochgezählt werden muss. Der Cache liegt unter `.pytest_db_cache/`
-und kann jederzeit gelöscht werden.
+Der Schlüssel umfasst neben der Eingabe-XML alles, was bestimmt, *wie* gebaut wird: alle Dateien unter
+`src/fundamend` (inklusive der `.sql`-View-Definitionen), `uv.lock` und die Testquellen – eine
+Code-Änderung invalidiert den Cache also selbst, eine Versionsnummer zum Hochzählen gibt es nicht.
+Erfasst wird allerdings `uv.lock`, nicht die tatsächlich installierten Pakete: nach einem Eingriff in
+die Umgebung (oder einem Wechsel der Python-Version) sollte man `.pytest_db_cache/` löschen – das ist
+jederzeit unbedenklich. Nebenbei sammeln sich Kopien im Temp-Verzeichnis, die niemand aufräumt.
 
 ## Hochfrequenz
 Die [Hochfrequenz Unternehmensberatung GmbH](https://www.hochfrequenz.de) ist eine Beratung für Energieversorger im deutschsprachigen Raum.

--- a/docs/superpowers/specs/2026-08-10-local-db-cache-opt-in-design.md
+++ b/docs/superpowers/specs/2026-08-10-local-db-cache-opt-in-design.md
@@ -60,7 +60,8 @@ uv run pytest
    `cached_ahb_db` used `f"ahb_raw_drop{int(drop_raw_tables)}"` — because `drop_raw_tables` changes
    the resulting schema for otherwise identical inputs
 2. for each input file, sorted: its path, `gueltig_von`, `gueltig_bis` and its contents. The path is
-   normalised to a **repo-relative POSIX path** (`PurePath.relative_to(repo_root).as_posix()`) before
+   normalised to a **repo-relative POSIX path** (`path.resolve().relative_to(repo_root.resolve())
+   .as_posix()`; resolving both sides so a mixed-case or short-name Windows path still matches) before
    hashing. The pre-removal implementation hashed `str(path)`, i.e. an absolute, OS-flavoured path,
    which makes the fingerprint depend on where the checkout happens to live and on the path
    separator. Normalising means moving or re-cloning a checkout does not throw away the whole cache,
@@ -141,8 +142,9 @@ should not be described as the OS reaping them. Each copy is roughly the size of
 so a developer running the suite repeatedly with the cache on will want to clear their temp directory
 occasionally. Adding lifecycle management is possible but out of scope here.
 
-**The cache directory is part of the injectable paths object**, as a fourth field alongside the
-source root, lock path and unittests root, defaulting to `<repo>/.pytest_db_cache`. Four of the
+**The cache directory is part of the injectable paths object**, alongside the source root, lock path,
+unittests root and (as implemented) the repo root that path normalisation needs — five fields in all,
+with the cache directory defaulting to `<repo>/.pytest_db_cache`. Four of the
 tests below need to control it — "no directory is created", the disabling values, the cold/warm
 sequence, and the fallback case. Without injection those tests would read and write the developer's
 real cache: the cold/warm test would pollute it, and "no directory is created" would fail on any
@@ -211,9 +213,10 @@ back. Check before pushing rather than spending a CI round-trip on it.
 
 ## Delivery
 
-This work lives on branch `local-db-cache-opt-in`, opened as PR #323 with this document as its only
-content so the design can be argued with before it is built. Implementation commits follow on the
-same branch once the design is signed off.
+This document went out as PR #323 on branch `local-db-cache-opt-in`, on its own so the design could be
+argued with before it was built, and was merged as `1ef1765`. The implementation follows in PR #324 on
+branch `local-db-cache-impl` — a separate branch rather than further commits on the design branch,
+because #323 auto-merged (and its branch was deleted) while the implementation was being written.
 
 The branch was originally stacked on `remove-test-db-cache`. That branch has since been squash-merged
 as `bab5b4f`, and because the repository is squash-merge-only the pre-merge commits never became

--- a/domain-specific-terms.txt
+++ b/domain-specific-terms.txt
@@ -20,3 +20,6 @@ contrl
 Elemente
 segmente
 hierarchie
+lokal
+unter
+relevante

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ cli = [
 
 [dependency-groups]
 tests = [
+    "filelock==3.32.2",
     "pytest==9.1.1",
     "pytest-xdist==3.8.0",
     "syrupy==5.5.3"

--- a/unittests/_db_cache.py
+++ b/unittests/_db_cache.py
@@ -43,8 +43,8 @@ _REPO_ROOT = Path(__file__).parent.parent
 # invalidate entries for no reason.
 _IGNORED_DIRECTORIES = frozenset({"__pycache__", "__snapshots__", "example_files"})
 
-# Type of the file lists accepted by fundamend's DB builders.
-_AhbFile = Path | tuple[Path, date, date | None] | tuple[Path, None, None]
+# Type of the file lists accepted by fundamend's DB builders (AHB and MIG alike).
+_XmlInputFile = Path | tuple[Path, date, date | None] | tuple[Path, None, None]
 
 
 @dataclass(frozen=True)
@@ -154,7 +154,7 @@ def _normalized_path(path: Path, repo_root: Path) -> str:
         return path.resolve().as_posix()
 
 
-def fingerprint(recipe: str, files: Iterable[_AhbFile], *, paths: CachePaths = DEFAULT_PATHS) -> str:
+def fingerprint(recipe: str, files: Iterable[_XmlInputFile], *, paths: CachePaths = DEFAULT_PATHS) -> str:
     """
     Return a short, stable hash identifying a database build.
 
@@ -237,15 +237,15 @@ def cached_db(key: str, builder: Callable[[], Path], *, paths: CachePaths = DEFA
     except OSError as error:
         _warn_unusable(error)
         return builder()
-    built: Path | None = None
     try:
         if not cached.exists():
             built = builder()  # outside every OSError handler: builder failures must propagate
-            if not _publish(built, cached):
-                return built
+            _publish(built, cached)  # warns on failure; either way the freshly built file is good
+            # Return the build itself rather than copying it back out of the cache: it is already a
+            # private throwaway file, so copying would double the I/O on the slowest path and leave
+            # the original behind in the temp directory for nothing.
+            return built
         private_copy = _private_copy(cached)
     finally:
         file_lock.release()
-    if private_copy is not None:
-        return private_copy
-    return built if built is not None else builder()
+    return private_copy if private_copy is not None else builder()

--- a/unittests/_db_cache.py
+++ b/unittests/_db_cache.py
@@ -1,0 +1,199 @@
+"""
+Opt-in, local-only cache for the SQLite databases the tests build from the AHB/MIG XML corpus.
+
+Building one of these databases is slow (XML parsing plus ``ahbicht`` expression evaluation) and the
+suite triggers dozens of builds, so developers can cache the finished ``.sqlite`` files on disk.
+
+Two properties make this safe, and both are load-bearing:
+
+1. **It is off unless you ask for it.** Set ``FUNDAMEND_TEST_DB_CACHE=1`` to enable it. Without that,
+   :func:`cached_db` simply calls the builder -- no directory, no lock, no copy. CI sets nothing, so
+   a cached run cannot produce a green CI result.
+2. **The key covers the code, not just the data.** :func:`fingerprint` hashes the builder sources
+   (every file under ``src/fundamend``, including the ``.sql`` view definitions that are read at
+   runtime), ``uv.lock`` and the test sources, on top of the input XML. Any change to how a database
+   is built therefore changes the key on its own.
+
+Property 2 is why there is no ``_CACHE_VERSION`` constant to bump by hand. An earlier version of this
+module keyed entries on the input XML alone, which meant a change to a reader or a view definition
+was served a database built by the *previous* version of the code, and the suite went green without
+having seen the change. See PR #321 for the removal and PR #323 for this design.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import tempfile
+import warnings
+from collections.abc import Callable, Iterable, Iterator
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+from filelock import FileLock
+
+_ENV_VAR = "FUNDAMEND_TEST_DB_CACHE"
+_ENABLING_VALUES = frozenset({"1", "true", "yes"})
+
+_REPO_ROOT = Path(__file__).parent.parent
+
+# Directories that never influence a built database, so hashing them would only cost time and
+# invalidate entries for no reason.
+_IGNORED_DIRECTORIES = frozenset({"__pycache__", "__snapshots__", "example_files"})
+
+# Type of the file lists accepted by fundamend's DB builders.
+_AhbFile = Path | tuple[Path, date, date | None] | tuple[Path, None, None]
+
+
+@dataclass(frozen=True)
+class CachePaths:
+    """
+    Every filesystem location this module touches, in one injectable (and hashable) bundle.
+
+    Production code uses :data:`DEFAULT_PATHS`; the tests point these at temporary directories so
+    they neither read nor write a developer's real cache.
+    """
+
+    repo_root: Path
+    source_root: Path
+    lock_path: Path
+    unittests_root: Path
+    cache_dir: Path
+
+
+DEFAULT_PATHS = CachePaths(
+    repo_root=_REPO_ROOT,
+    source_root=_REPO_ROOT / "src" / "fundamend",
+    lock_path=_REPO_ROOT / "uv.lock",
+    unittests_root=_REPO_ROOT / "unittests",
+    cache_dir=_REPO_ROOT / ".pytest_db_cache",
+)
+
+# Keyed on the paths bundle rather than computed once per process: the invalidation tests compute
+# fingerprints from several different stubbed roots inside a single pytest process.
+_CODE_FINGERPRINTS: dict[CachePaths, str] = {}
+
+
+def is_enabled() -> bool:
+    """Return whether the cache is switched on. Read on every call so tests can monkeypatch it."""
+    return os.environ.get(_ENV_VAR, "").strip().lower() in _ENABLING_VALUES
+
+
+def _relevant_files(root: Path, only_python: bool) -> Iterator[Path]:
+    """Yield the files under ``root`` whose contents can influence a built database, sorted."""
+    if not root.is_dir():
+        return
+    for path in sorted(root.rglob("*")):
+        relative_parts = path.relative_to(root).parts
+        if any(part in _IGNORED_DIRECTORIES for part in relative_parts):
+            continue
+        if not path.is_file() or path.suffix == ".pyc":
+            continue
+        if only_python and path.suffix != ".py":
+            continue
+        yield path
+
+
+def _code_fingerprint(paths: CachePaths) -> str:
+    """
+    Hash everything that determines what a built database contains, except its XML inputs.
+
+    ``src/fundamend`` is hashed in full rather than by ``*.py``: the package ships six ``.sql`` files
+    which :func:`fundamend.sqlmodels.internals._execute_bare_sql` reads from disk and executes into
+    the database, and editing one of those is the most likely way to change a database's content.
+    """
+    memoized = _CODE_FINGERPRINTS.get(paths)
+    if memoized is not None:
+        return memoized
+    hasher = hashlib.sha256()
+    for label, root, only_python in (
+        ("src", paths.source_root, False),
+        ("unittests", paths.unittests_root, True),
+    ):
+        hasher.update(f"\0root:{label}\0".encode())
+        for path in _relevant_files(root, only_python=only_python):
+            hasher.update(path.relative_to(root).as_posix().encode())
+            hasher.update(path.read_bytes())
+    hasher.update(b"\0lock\0")
+    if paths.lock_path.is_file():
+        hasher.update(paths.lock_path.read_bytes())
+    fingerprint_of_code = hasher.hexdigest()
+    _CODE_FINGERPRINTS[paths] = fingerprint_of_code
+    return fingerprint_of_code
+
+
+def _normalized_path(path: Path, repo_root: Path) -> str:
+    """
+    Return ``path`` as a repo-relative POSIX string.
+
+    Hashing the absolute path would tie the key to where the checkout happens to live and to the
+    platform's path separator, so moving a checkout would silently discard the whole cache. The
+    relative path still distinguishes two different files that happen to have identical contents.
+    """
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:  # an input from outside the repository; not something the suite does today
+        return path.resolve().as_posix()
+
+
+def fingerprint(recipe: str, files: Iterable[_AhbFile], *, paths: CachePaths = DEFAULT_PATHS) -> str:
+    """
+    Return a short, stable hash identifying a database build.
+
+    ``recipe`` names the build variant and must encode the builder flags (``drop_raw_tables``
+    changes the resulting schema for otherwise identical inputs). ``files`` is the exact input set;
+    both the paths and the contents are hashed, so the fingerprint is correct even if the submodule
+    is checked out at a different commit or locally modified. The file order does not matter.
+    """
+    hasher = hashlib.sha256()
+    hasher.update(recipe.encode())
+    hasher.update(_code_fingerprint(paths).encode())
+    normalized: list[tuple[str, str, str, Path]] = []
+    for item in files:
+        if isinstance(item, Path):
+            path, von, bis = item, "", ""
+        else:
+            path = item[0]
+            von = "" if item[1] is None else item[1].isoformat()
+            bis = "" if item[2] is None else item[2].isoformat()
+        normalized.append((_normalized_path(path, paths.repo_root), von, bis, path))
+    for relative_path, von, bis, path in sorted(normalized, key=lambda entry: entry[:3]):
+        hasher.update(relative_path.encode())
+        hasher.update(von.encode())
+        hasher.update(bis.encode())
+        hasher.update(path.read_bytes())
+    return hasher.hexdigest()[:32]
+
+
+def cached_db(key: str, builder: Callable[[], Path], *, paths: CachePaths = DEFAULT_PATHS) -> Path:
+    """
+    Return a path to a ready-to-use SQLite database for ``key``, building it at most once.
+
+    Without ``FUNDAMEND_TEST_DB_CACHE`` set this is a thin pass-through to ``builder``. With it set,
+    a cache miss invokes ``builder`` exactly once across all pytest-xdist workers (the file lock) and
+    publishes the result atomically, so an interrupted run can never leave a truncated entry behind
+    for later runs to reuse. Every caller receives its own copy, so concurrent sessions never contend
+    on one database file.
+
+    The cache never gets a vote on whether the suite can run: any filesystem problem degrades to a
+    direct build with a warning.
+    """
+    if not is_enabled():
+        return builder()
+    try:
+        paths.cache_dir.mkdir(parents=True, exist_ok=True)
+        cached = paths.cache_dir / f"{key}.sqlite"
+        with FileLock(f"{cached}.lock"):
+            if not cached.exists():
+                built = builder()
+                being_written = cached.with_suffix(".sqlite.building")
+                shutil.copyfile(built, being_written)
+                being_written.replace(cached)  # atomic publish; readers never see a partial file
+        consumer_copy = Path(tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False).name)
+        shutil.copyfile(cached, consumer_copy)
+        return consumer_copy
+    except OSError as error:
+        warnings.warn(f"test database cache unusable ({error}); building directly", stacklevel=2)
+        return builder()

--- a/unittests/_db_cache.py
+++ b/unittests/_db_cache.py
@@ -113,12 +113,28 @@ def _code_fingerprint(paths: CachePaths) -> str:
         ("unittests", paths.unittests_root, True),
     ):
         hasher.update(f"\0root:{label}\0".encode())
+        if not root.is_dir():
+            # A root that does not exist must *change* the key, never silently shrink it. Without
+            # this, renaming the package directory (or a typo in DEFAULT_PATHS) would reduce the
+            # fingerprint to "everything else" and quietly stop invalidating on builder changes --
+            # the PR #321 defect, reached through a path mistake instead of a narrow glob.
+            hasher.update(b"\0MISSING\0")
+            hasher.update(str(root).encode())
+            continue
         for path in _relevant_files(root, only_python=only_python):
-            hasher.update(path.relative_to(root).as_posix().encode())
-            hasher.update(path.read_bytes())
+            contents = path.read_bytes()
+            # Frame each entry with its length so that name and contents cannot run together:
+            # "a.py" + b"bX" must not hash like "a.pyb" + b"X".
+            hasher.update(f"\0{path.relative_to(root).as_posix()}\0{len(contents)}\0".encode())
+            hasher.update(contents)
     hasher.update(b"\0lock\0")
     if paths.lock_path.is_file():
-        hasher.update(paths.lock_path.read_bytes())
+        lock_contents = paths.lock_path.read_bytes()
+        hasher.update(f"\0{len(lock_contents)}\0".encode())
+        hasher.update(lock_contents)
+    else:
+        hasher.update(b"\0MISSING\0")
+        hasher.update(str(paths.lock_path).encode())
     fingerprint_of_code = hasher.hexdigest()
     _CODE_FINGERPRINTS[paths] = fingerprint_of_code
     return fingerprint_of_code
@@ -160,11 +176,40 @@ def fingerprint(recipe: str, files: Iterable[_AhbFile], *, paths: CachePaths = D
             bis = "" if item[2] is None else item[2].isoformat()
         normalized.append((_normalized_path(path, paths.repo_root), von, bis, path))
     for relative_path, von, bis, path in sorted(normalized, key=lambda entry: entry[:3]):
-        hasher.update(relative_path.encode())
-        hasher.update(von.encode())
-        hasher.update(bis.encode())
-        hasher.update(path.read_bytes())
+        contents = path.read_bytes()
+        # Length-framed for the same reason as in _code_fingerprint: von/bis are variable length
+        # (empty or a 10-character ISO date), so unframed concatenation would be ambiguous.
+        hasher.update(f"\0{relative_path}\0{von}\0{bis}\0{len(contents)}\0".encode())
+        hasher.update(contents)
     return hasher.hexdigest()[:32]
+
+
+def _warn_unusable(error: OSError) -> None:
+    warnings.warn(f"test database cache unusable ({error}); building directly", stacklevel=3)
+
+
+def _publish(built: Path, cached: Path) -> bool:
+    """Copy ``built`` into the cache atomically; return whether that worked."""
+    try:
+        being_written = cached.with_suffix(".sqlite.building")
+        shutil.copyfile(built, being_written)
+        being_written.replace(cached)  # atomic publish; readers never see a partial file
+        return True
+    except OSError as error:
+        _warn_unusable(error)
+        return False
+
+
+def _private_copy(cached: Path) -> Path | None:
+    """Return the caller its own copy of a cached database, or ``None`` if that is not possible."""
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as handle:
+            consumer_copy = Path(handle.name)
+        shutil.copyfile(cached, consumer_copy)
+        return consumer_copy
+    except OSError as error:
+        _warn_unusable(error)
+        return None
 
 
 def cached_db(key: str, builder: Callable[[], Path], *, paths: CachePaths = DEFAULT_PATHS) -> Path:
@@ -178,22 +223,29 @@ def cached_db(key: str, builder: Callable[[], Path], *, paths: CachePaths = DEFA
     on one database file.
 
     The cache never gets a vote on whether the suite can run: any filesystem problem degrades to a
-    direct build with a warning.
+    direct build with a warning. Failures raised by ``builder`` itself are *not* caught -- they are
+    bugs in the code under test, and dressing them up as cache problems would send whoever is
+    debugging them in the wrong direction.
     """
     if not is_enabled():
         return builder()
+    cached = paths.cache_dir / f"{key}.sqlite"
     try:
         paths.cache_dir.mkdir(parents=True, exist_ok=True)
-        cached = paths.cache_dir / f"{key}.sqlite"
-        with FileLock(f"{cached}.lock"):
-            if not cached.exists():
-                built = builder()
-                being_written = cached.with_suffix(".sqlite.building")
-                shutil.copyfile(built, being_written)
-                being_written.replace(cached)  # atomic publish; readers never see a partial file
-        consumer_copy = Path(tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False).name)
-        shutil.copyfile(cached, consumer_copy)
-        return consumer_copy
+        file_lock = FileLock(f"{cached}.lock")
+        file_lock.acquire()
     except OSError as error:
-        warnings.warn(f"test database cache unusable ({error}); building directly", stacklevel=2)
+        _warn_unusable(error)
         return builder()
+    built: Path | None = None
+    try:
+        if not cached.exists():
+            built = builder()  # outside every OSError handler: builder failures must propagate
+            if not _publish(built, cached):
+                return built
+        private_copy = _private_copy(cached)
+    finally:
+        file_lock.release()
+    if private_copy is not None:
+        return private_copy
+    return built if built is not None else builder()

--- a/unittests/conftest.py
+++ b/unittests/conftest.py
@@ -18,7 +18,7 @@ from fundamend.sqlmodels.ahb_formatversion_diff_view import create_ahb_formatver
 from fundamend.sqlmodels.ahb_pruefi_diff_view import create_ahb_pruefi_diff_view
 from fundamend.sqlmodels.expression_view import create_and_fill_ahb_expression_table
 
-from ._db_cache import _AhbFile, cached_db, fingerprint
+from ._db_cache import _XmlInputFile, cached_db, fingerprint
 
 # The ahbicht condition-expression parser (and its lark backend) can emit large volumes of
 # DEBUG/INFO log lines while the expensive DB fixtures parse every AHB expression. Formatting
@@ -66,7 +66,7 @@ def apply_throwaway_sqlite_pragmas(engine: Engine) -> None:
 # =============================================================================
 
 
-def cached_ahb_db(ahb_files: Iterable[_AhbFile], drop_raw_tables: bool = False) -> Path:
+def cached_ahb_db(ahb_files: Iterable[_XmlInputFile], drop_raw_tables: bool = False) -> Path:
     """
     Like :func:`create_db_and_populate_with_ahb_view`, but served from the opt-in local cache.
 
@@ -83,7 +83,7 @@ def cached_ahb_db(ahb_files: Iterable[_AhbFile], drop_raw_tables: bool = False) 
     )
 
 
-def cached_mig_db(mig_files: Iterable[_AhbFile], drop_raw_tables: bool = False) -> Path:
+def cached_mig_db(mig_files: Iterable[_XmlInputFile], drop_raw_tables: bool = False) -> Path:
     """MIG counterpart of :func:`cached_ahb_db`."""
     mig_files = list(mig_files)
     recipe = f"mig_raw_drop{int(drop_raw_tables)}"
@@ -93,7 +93,7 @@ def cached_mig_db(mig_files: Iterable[_AhbFile], drop_raw_tables: bool = False) 
     )
 
 
-def _build_ahb_db_with_diff_view(ahb_files: Sequence[_AhbFile]) -> Path:
+def _build_ahb_db_with_diff_view(ahb_files: Sequence[_XmlInputFile]) -> Path:
     """Build a complete AHB database file: raw tables + expression table + ahbtabellen + diff views."""
     db_path = create_db_and_populate_with_ahb_view(ahb_files=ahb_files, drop_raw_tables=False)
     engine = create_engine(f"sqlite:///{db_path}")
@@ -128,7 +128,7 @@ def session_fv2410_fv2504_with_diff_view() -> Generator[Session, None, None]:
     if not is_private_submodule_checked_out():
         pytest.skip("Skipping test because of missing private submodule")
 
-    ahb_files: Sequence[_AhbFile] = [
+    ahb_files: Sequence[_XmlInputFile] = [
         (p, date(2024, 10, 1), date(2025, 6, 6)) for p in (private_submodule_root / "FV2410").rglob("**/*AHB*.xml")
     ] + [(p, date(2025, 6, 6), None) for p in (private_submodule_root / "FV2504").rglob("**/*AHB*.xml")]
 
@@ -151,7 +151,7 @@ def session_fv2510_fv2604_mscons_with_diff_view() -> Generator[Session, None, No
     if not is_private_submodule_checked_out():
         pytest.skip("Skipping test because of missing private submodule")
 
-    ahb_files: Sequence[_AhbFile] = [
+    ahb_files: Sequence[_XmlInputFile] = [
         (p, date(2025, 10, 1), date(2026, 4, 1))
         for p in (private_submodule_root / "FV2510").rglob("**/MSCONS_AHB*.xml")
     ] + [(p, date(2026, 4, 1), None) for p in (private_submodule_root / "FV2604").rglob("**/MSCONS_AHB*.xml")]

--- a/unittests/conftest.py
+++ b/unittests/conftest.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import Generator, Sequence
+from collections.abc import Generator, Iterable, Sequence
 from datetime import date
 from pathlib import Path
 from typing import Any
@@ -9,13 +9,16 @@ from sqlalchemy import event
 from sqlalchemy.engine import Engine
 from sqlmodel import Session, create_engine
 
-from fundamend.sqlmodels import create_ahbtabellen_view, create_db_and_populate_with_ahb_view
+from fundamend.sqlmodels import (
+    create_ahbtabellen_view,
+    create_db_and_populate_with_ahb_view,
+    create_db_and_populate_with_mig_view,
+)
 from fundamend.sqlmodels.ahb_formatversion_diff_view import create_ahb_formatversion_diff_view
 from fundamend.sqlmodels.ahb_pruefi_diff_view import create_ahb_pruefi_diff_view
 from fundamend.sqlmodels.expression_view import create_and_fill_ahb_expression_table
 
-# Type of the file lists accepted by fundamend's DB builders.
-_AhbFile = Path | tuple[Path, date, date | None] | tuple[Path, None, None]
+from ._db_cache import _AhbFile, cached_db, fingerprint
 
 # The ahbicht condition-expression parser (and its lark backend) can emit large volumes of
 # DEBUG/INFO log lines while the expensive DB fixtures parse every AHB expression. Formatting
@@ -53,6 +56,43 @@ def apply_throwaway_sqlite_pragmas(engine: Engine) -> None:
     event.listen(engine, "connect", _set_sqlite_pragmas)
 
 
+# =============================================================================
+# Cached database builders
+# =============================================================================
+# The DB builders in fundamend.sqlmodels are deterministic up to generated ids, so identical inputs
+# always yield an equivalent database. Building one is slow (XML parsing + ahbicht), so these helpers
+# can serve the result from an on-disk cache -- but only for developers who opted in locally with
+# FUNDAMEND_TEST_DB_CACHE=1. Unset (as in CI) they build directly. See unittests/_db_cache.py.
+# =============================================================================
+
+
+def cached_ahb_db(ahb_files: Iterable[_AhbFile], drop_raw_tables: bool = False) -> Path:
+    """
+    Like :func:`create_db_and_populate_with_ahb_view`, but served from the opt-in local cache.
+
+    The returned database is equivalent to a fresh build (same inserts and view; only generated ids
+    differ), so callers -- including snapshot tests -- observe identical query results while the
+    underlying XML parsing/materialization happens only once per unique input set. With the cache
+    disabled, which is the default and always the case in CI, this is a plain build.
+    """
+    ahb_files = list(ahb_files)
+    recipe = f"ahb_raw_drop{int(drop_raw_tables)}"
+    key = f"{recipe}_{fingerprint(recipe, ahb_files)}"
+    return cached_db(
+        key, lambda: create_db_and_populate_with_ahb_view(ahb_files=ahb_files, drop_raw_tables=drop_raw_tables)
+    )
+
+
+def cached_mig_db(mig_files: Iterable[_AhbFile], drop_raw_tables: bool = False) -> Path:
+    """MIG counterpart of :func:`cached_ahb_db`."""
+    mig_files = list(mig_files)
+    recipe = f"mig_raw_drop{int(drop_raw_tables)}"
+    key = f"{recipe}_{fingerprint(recipe, mig_files)}"
+    return cached_db(
+        key, lambda: create_db_and_populate_with_mig_view(mig_files=mig_files, drop_raw_tables=drop_raw_tables)
+    )
+
+
 def _build_ahb_db_with_diff_view(ahb_files: Sequence[_AhbFile]) -> Path:
     """Build a complete AHB database file: raw tables + expression table + ahbtabellen + diff views."""
     db_path = create_db_and_populate_with_ahb_view(ahb_files=ahb_files, drop_raw_tables=False)
@@ -82,8 +122,8 @@ def session_fv2410_fv2504_with_diff_view() -> Generator[Session, None, None]:
     Includes: ahb_hierarchy_materialized, ahb_expressions, v_ahbtabellen,
     v_ahb_formatversion_diff, v_ahb_pruefi_diff.
 
-    This fixture is expensive to create, so it is module-scoped: every test in a module shares one
-    build.
+    This fixture is expensive to create: it is module-scoped, and for developers who opted into the
+    local cache the fully-built database is reused across modules and runs as well.
     """
     if not is_private_submodule_checked_out():
         pytest.skip("Skipping test because of missing private submodule")
@@ -92,7 +132,8 @@ def session_fv2410_fv2504_with_diff_view() -> Generator[Session, None, None]:
         (p, date(2024, 10, 1), date(2025, 6, 6)) for p in (private_submodule_root / "FV2410").rglob("**/*AHB*.xml")
     ] + [(p, date(2025, 6, 6), None) for p in (private_submodule_root / "FV2504").rglob("**/*AHB*.xml")]
 
-    db_path = _build_ahb_db_with_diff_view(ahb_files)
+    recipe = "ahb_fv2410_fv2504_with_diff_view"
+    db_path = cached_db(f"{recipe}_{fingerprint(recipe, ahb_files)}", lambda: _build_ahb_db_with_diff_view(ahb_files))
     engine = create_engine(f"sqlite:///{db_path}")
     with Session(bind=engine) as session:
         yield session
@@ -115,7 +156,8 @@ def session_fv2510_fv2604_mscons_with_diff_view() -> Generator[Session, None, No
         for p in (private_submodule_root / "FV2510").rglob("**/MSCONS_AHB*.xml")
     ] + [(p, date(2026, 4, 1), None) for p in (private_submodule_root / "FV2604").rglob("**/MSCONS_AHB*.xml")]
 
-    db_path = _build_ahb_db_with_diff_view(ahb_files)
+    recipe = "ahb_fv2510_fv2604_mscons_with_diff_view"
+    db_path = cached_db(f"{recipe}_{fingerprint(recipe, ahb_files)}", lambda: _build_ahb_db_with_diff_view(ahb_files))
     engine = create_engine(f"sqlite:///{db_path}")
     with Session(bind=engine) as session:
         yield session

--- a/unittests/test_ahb_formatversion_diff_view.py
+++ b/unittests/test_ahb_formatversion_diff_view.py
@@ -5,10 +5,10 @@ from efoli import EdifactFormatVersion
 from sqlmodel import Session, create_engine, select, text
 from syrupy.assertion import SnapshotAssertion
 
-from fundamend.sqlmodels import create_ahbtabellen_view, create_db_and_populate_with_ahb_view
+from fundamend.sqlmodels import create_ahbtabellen_view
 from fundamend.sqlmodels.ahb_formatversion_diff_view import AhbFormatversionDiffLine, create_ahb_formatversion_diff_view
 
-from .conftest import is_private_submodule_checked_out, private_submodule_root
+from .conftest import cached_ahb_db, is_private_submodule_checked_out, private_submodule_root
 
 
 @pytest.mark.snapshot
@@ -23,7 +23,7 @@ def test_ahb_formatversion_diff_view_various_pruefis(snapshot: SnapshotAssertion
         (p, date(2024, 10, 1), date(2025, 6, 6)) for p in (private_submodule_root / "FV2410").rglob("**/*AHB*.xml")
     ] + [(p, date(2025, 6, 6), None) for p in (private_submodule_root / "FV2504").rglob("**/*AHB*.xml")]
 
-    actual_sqlite_path = create_db_and_populate_with_ahb_view(ahb_files=ahb_paths, drop_raw_tables=False)
+    actual_sqlite_path = cached_ahb_db(ahb_paths, drop_raw_tables=False)
     assert actual_sqlite_path.exists()
     engine = create_engine(f"sqlite:///{actual_sqlite_path}")
     results: list[AhbFormatversionDiffLine] = []

--- a/unittests/test_db_cache.py
+++ b/unittests/test_db_cache.py
@@ -12,13 +12,16 @@ contents, since the cache does not care what is inside them.
 
 from __future__ import annotations
 
+import shutil
 import sqlite3
+from collections.abc import Callable
+from dataclasses import replace
 from datetime import date
 from pathlib import Path
 
 import pytest
 
-from ._db_cache import CachePaths, cached_db, fingerprint, is_enabled
+from ._db_cache import DEFAULT_PATHS, CachePaths, cached_db, fingerprint, is_enabled
 
 _ENV_VAR = "FUNDAMEND_TEST_DB_CACHE"
 
@@ -52,7 +55,7 @@ def _make_input(paths: CachePaths, name: str, content: str = "<AHB/>") -> Path:
     return path
 
 
-def _counting_builder(tmp_path: Path, calls: list[int], content: str = "payload") -> object:
+def _counting_builder(tmp_path: Path, calls: list[int], content: str = "payload") -> Callable[[], Path]:
     """Return a builder that records every invocation and writes a real (tiny) SQLite file."""
 
     def build() -> Path:
@@ -83,8 +86,8 @@ def test_disabled_by_default_builds_every_time(
     calls: list[int] = []
     builder = _counting_builder(tmp_path, calls)
 
-    first = cached_db("some-key", builder, paths=paths)  # type: ignore[arg-type]
-    second = cached_db("some-key", builder, paths=paths)  # type: ignore[arg-type]
+    first = cached_db("some-key", builder, paths=paths)
+    second = cached_db("some-key", builder, paths=paths)
 
     assert len(calls) == 2, "with the cache disabled every call must build"
     assert _read_back(first) == ["payload"]
@@ -99,8 +102,8 @@ def test_non_enabling_values_keep_the_cache_off(
     monkeypatch.setenv(_ENV_VAR, value)
     calls: list[int] = []
 
-    cached_db("some-key", _counting_builder(tmp_path, calls), paths=paths)  # type: ignore[arg-type]
-    cached_db("some-key", _counting_builder(tmp_path, calls), paths=paths)  # type: ignore[arg-type]
+    cached_db("some-key", _counting_builder(tmp_path, calls), paths=paths)
+    cached_db("some-key", _counting_builder(tmp_path, calls), paths=paths)
 
     assert not is_enabled()
     assert len(calls) == 2
@@ -120,8 +123,8 @@ def test_enabled_builds_once_and_serves_copies(
     calls: list[int] = []
     builder = _counting_builder(tmp_path, calls)
 
-    first = cached_db("some-key", builder, paths=paths)  # type: ignore[arg-type]
-    second = cached_db("some-key", builder, paths=paths)  # type: ignore[arg-type]
+    first = cached_db("some-key", builder, paths=paths)
+    second = cached_db("some-key", builder, paths=paths)
 
     assert len(calls) == 1, "the second request must be served from the cache"
     assert _read_back(first) == _read_back(second) == ["payload"]
@@ -134,8 +137,8 @@ def test_different_keys_do_not_share_an_entry(
     monkeypatch.setenv(_ENV_VAR, "1")
     calls: list[int] = []
 
-    cached_db("key-a", _counting_builder(tmp_path, calls, "a"), paths=paths)  # type: ignore[arg-type]
-    second = cached_db("key-b", _counting_builder(tmp_path, calls, "b"), paths=paths)  # type: ignore[arg-type]
+    cached_db("key-a", _counting_builder(tmp_path, calls, "a"), paths=paths)
+    second = cached_db("key-b", _counting_builder(tmp_path, calls, "b"), paths=paths)
 
     assert len(calls) == 2
     assert _read_back(second) == ["b"]
@@ -159,7 +162,7 @@ def test_unusable_cache_directory_falls_back_to_building(
     calls: list[int] = []
 
     with pytest.warns(UserWarning, match="cache unusable"):
-        built = cached_db("some-key", _counting_builder(tmp_path, calls), paths=unusable)  # type: ignore[arg-type]
+        built = cached_db("some-key", _counting_builder(tmp_path, calls), paths=unusable)
 
     assert len(calls) == 1
     assert _read_back(built) == ["payload"], "a broken cache must never break the run"
@@ -193,6 +196,40 @@ def test_input_content_change_invalidates(paths: CachePaths) -> None:
     assert fingerprint("recipe", [file], paths=paths) != before
 
 
+def test_input_path_change_invalidates(paths: CachePaths) -> None:
+    """Two files with identical contents at different paths must not share a cache entry."""
+    here = _make_input(paths, "FV2410/MSCONS_AHB.xml", "<AHB/>")
+    there = _make_input(paths, "FV2504/MSCONS_AHB.xml", "<AHB/>")
+    assert here.read_bytes() == there.read_bytes(), "the point of this test is identical contents"
+    assert fingerprint("recipe", [here], paths=paths) != fingerprint("recipe", [there], paths=paths)
+
+
+def test_fingerprint_survives_moving_the_checkout(paths: CachePaths, tmp_path: Path) -> None:
+    """
+    Paths enter the key repo-relative, so relocating a checkout must not discard the cache.
+
+    The pre-removal implementation hashed ``str(path)``, i.e. an absolute, OS-flavoured path; this
+    test fails if that ever comes back.
+    """
+    original_input = _make_input(paths, "FV2410/MSCONS_AHB.xml")
+    before = fingerprint("recipe", [original_input], paths=paths)
+
+    moved_root = tmp_path / "somewhere" / "else" / "repo"
+    moved_root.parent.mkdir(parents=True)
+    shutil.copytree(paths.repo_root, moved_root)
+    moved = replace(
+        paths,
+        repo_root=moved_root,
+        source_root=moved_root / "src" / "fundamend",
+        lock_path=moved_root / "uv.lock",
+        unittests_root=moved_root / "unittests",
+        cache_dir=moved_root / "cache",
+    )
+
+    after = fingerprint("recipe", [moved_root / "xml-migs-and-ahbs" / "FV2410" / "MSCONS_AHB.xml"], paths=moved)
+    assert after == before, "an identical tree at a different absolute location must hash the same"
+
+
 def test_input_validity_dates_change_invalidates(paths: CachePaths) -> None:
     file = _make_input(paths, "MSCONS_AHB.xml")
     early = fingerprint("recipe", [(file, date(2024, 10, 1), None)], paths=paths)
@@ -200,7 +237,7 @@ def test_input_validity_dates_change_invalidates(paths: CachePaths) -> None:
     assert early != late
 
 
-def _fingerprint_of_variant(paths: CachePaths, mutate: object) -> str:
+def _fingerprint_of_variant(paths: CachePaths, mutate: Callable[[CachePaths], object]) -> str:
     """Build a second, independent stub tree that differs only as ``mutate`` says, and hash it."""
     variant_root = paths.repo_root.parent / "repo-variant"
     if variant_root.exists():
@@ -227,7 +264,7 @@ def _fingerprint_of_variant(paths: CachePaths, mutate: object) -> str:
         unittests_root=variant_unittests,
         cache_dir=variant_root / "cache",
     )
-    mutate(variant)  # type: ignore[operator]
+    mutate(variant)
     # the same input file, at the same repo-relative path, so only the code differs
     input_file = variant_root / "xml-migs-and-ahbs" / "MSCONS_AHB.xml"
     input_file.parent.mkdir(parents=True, exist_ok=True)
@@ -287,13 +324,76 @@ def test_ignored_directories_do_not_invalidate(paths: CachePaths) -> None:
     before = fingerprint("recipe", [baseline], paths=paths)
 
     def add_ignored_files(variant: CachePaths) -> None:
+        # These must land under the *source* root, which is walked without the only_python filter.
+        # Putting them under the unittests root would prove nothing: everything here lacks a .py
+        # suffix, so the only_python filter would drop them before the exclusion rules were consulted
+        # and the test would pass even with _IGNORED_DIRECTORIES emptied.
+        bytecode = variant.source_root / "__pycache__"
+        bytecode.mkdir()
+        (bytecode / "ahbview.cpython-312.pyc").write_bytes(b"\x00compiled")
+        nested = variant.source_root / "sqlmodels" / "__pycache__"
+        nested.mkdir(parents=True)
+        (nested / "internals.cpython-312.pyc").write_bytes(b"\x00compiled")
+        (variant.source_root / "ahbview.pyc").write_bytes(b"\x00loose bytecode")
+
+    after = _fingerprint_of_variant(paths, add_ignored_files)
+    assert after == before, (
+        "bytecode does not change how a database is built; if it did, ordinary recompilation "
+        "would invalidate every cache entry and the cache would silently stop caching"
+    )
+
+
+def test_snapshots_and_example_files_do_not_invalidate(paths: CachePaths) -> None:
+    baseline = _make_input(paths, "MSCONS_AHB.xml")
+    before = fingerprint("recipe", [baseline], paths=paths)
+
+    def add_test_data(variant: CachePaths) -> None:
         snapshots = variant.unittests_root / "__snapshots__"
         snapshots.mkdir()
+        # a .py inside an ignored directory: only _IGNORED_DIRECTORIES can keep this out
+        (snapshots / "helper.py").write_text("# not a builder\n", encoding="utf-8")
         (snapshots / "test_something.ambr").write_text("# serializer version: 1\n", encoding="utf-8")
         examples = variant.unittests_root / "example_files"
         examples.mkdir()
-        (examples / "UTILTS_AHB.xml").write_text("<AHB/>\n", encoding="utf-8")
-        (variant.unittests_root / "conftest.pyc").write_bytes(b"\x00compiled")
+        (examples / "conftest.py").write_text("# not a builder either\n", encoding="utf-8")
 
-    after = _fingerprint_of_variant(paths, add_ignored_files)
-    assert after == before, "snapshots, example files and bytecode do not change how a database is built"
+    after = _fingerprint_of_variant(paths, add_test_data)
+    assert after == before, "snapshots and example files do not influence how a database is built"
+
+
+def test_missing_source_root_changes_the_key(paths: CachePaths) -> None:
+    """A vanished root must invalidate, not silently shrink the fingerprint to 'everything else'."""
+    baseline = _make_input(paths, "MSCONS_AHB.xml")
+    with_root = fingerprint("recipe", [baseline], paths=paths)
+    without_root = fingerprint("recipe", [baseline], paths=replace(paths, source_root=paths.repo_root / "src" / "gone"))
+    other_missing_root = fingerprint(
+        "recipe", [baseline], paths=replace(paths, source_root=paths.repo_root / "src" / "also-gone")
+    )
+
+    assert without_root != with_root, "losing the source root must change the key"
+    assert without_root != other_missing_root, (
+        "two different missing roots must not collapse to the same key -- otherwise a renamed "
+        "package directory would leave every pre-rename entry looking valid forever"
+    )
+
+
+def test_missing_lock_file_changes_the_key(paths: CachePaths) -> None:
+    baseline = _make_input(paths, "MSCONS_AHB.xml")
+    with_lock = fingerprint("recipe", [baseline], paths=paths)
+    without_lock = fingerprint("recipe", [baseline], paths=replace(paths, lock_path=paths.repo_root / "gone.lock"))
+    assert with_lock != without_lock
+
+
+def test_default_paths_describe_the_real_repository() -> None:
+    """
+    Guards the failure mode that no other test can see: DEFAULT_PATHS pointing at nothing.
+
+    If the package or test directory is ever moved and these constants are not updated, the code
+    fingerprint silently stops covering the moved tree. That is PR #321's defect via a path mistake.
+    """
+    assert DEFAULT_PATHS.source_root.is_dir(), f"{DEFAULT_PATHS.source_root} does not exist"
+    assert DEFAULT_PATHS.unittests_root.is_dir(), f"{DEFAULT_PATHS.unittests_root} does not exist"
+    assert DEFAULT_PATHS.lock_path.is_file(), f"{DEFAULT_PATHS.lock_path} does not exist"
+    assert (DEFAULT_PATHS.repo_root / ".git").exists(), "repo_root should be the repository root"
+    # the .sql view definitions are the reason the source root is hashed in full rather than by *.py
+    assert list(DEFAULT_PATHS.source_root.rglob("*.sql")), "expected .sql view definitions under src/fundamend"

--- a/unittests/test_db_cache.py
+++ b/unittests/test_db_cache.py
@@ -394,6 +394,8 @@ def test_default_paths_describe_the_real_repository() -> None:
     assert DEFAULT_PATHS.source_root.is_dir(), f"{DEFAULT_PATHS.source_root} does not exist"
     assert DEFAULT_PATHS.unittests_root.is_dir(), f"{DEFAULT_PATHS.unittests_root} does not exist"
     assert DEFAULT_PATHS.lock_path.is_file(), f"{DEFAULT_PATHS.lock_path} does not exist"
-    assert (DEFAULT_PATHS.repo_root / ".git").exists(), "repo_root should be the repository root"
+    # pyproject.toml rather than .git: the suite must also pass from a source archive (a GitHub
+    # "Download ZIP" checkout has no .git), where these paths are still perfectly correct.
+    assert (DEFAULT_PATHS.repo_root / "pyproject.toml").is_file(), "repo_root should be the repository root"
     # the .sql view definitions are the reason the source root is hashed in full rather than by *.py
     assert list(DEFAULT_PATHS.source_root.rglob("*.sql")), "expected .sql view definitions under src/fundamend"

--- a/unittests/test_db_cache.py
+++ b/unittests/test_db_cache.py
@@ -1,0 +1,299 @@
+"""
+Tests for the opt-in test database cache.
+
+The invalidation tests are the regression tests for the defect that motivated PR #321: an earlier
+version of the cache keyed entries on the input XML alone, so a change to the code that builds a
+database left the key untouched and the suite asserted against a database built by the previous
+version of the code. These tests fail if anyone narrows the key back down.
+
+Everything here is fast and needs no submodule: the databases are ordinary files with made-up
+contents, since the cache does not care what is inside them.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from ._db_cache import CachePaths, cached_db, fingerprint, is_enabled
+
+_ENV_VAR = "FUNDAMEND_TEST_DB_CACHE"
+
+
+@pytest.fixture()
+def paths(tmp_path: Path) -> CachePaths:
+    """A complete set of cache paths inside tmp_path, so no test touches the real cache."""
+    repo_root = tmp_path / "repo"
+    source_root = repo_root / "src" / "fundamend"
+    unittests_root = repo_root / "unittests"
+    source_root.mkdir(parents=True)
+    unittests_root.mkdir(parents=True)
+    (source_root / "ahbview.py").write_text("def build(): ...\n", encoding="utf-8")
+    (source_root / "materialize_ahb_view.sql").write_text("select 1;\n", encoding="utf-8")
+    (unittests_root / "conftest.py").write_text("# fixtures\n", encoding="utf-8")
+    lock_path = repo_root / "uv.lock"
+    lock_path.write_text("ahbicht==1.0.0\n", encoding="utf-8")
+    return CachePaths(
+        repo_root=repo_root,
+        source_root=source_root,
+        lock_path=lock_path,
+        unittests_root=unittests_root,
+        cache_dir=tmp_path / "cache",
+    )
+
+
+def _make_input(paths: CachePaths, name: str, content: str = "<AHB/>") -> Path:
+    path = paths.repo_root / "xml-migs-and-ahbs" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _counting_builder(tmp_path: Path, calls: list[int], content: str = "payload") -> object:
+    """Return a builder that records every invocation and writes a real (tiny) SQLite file."""
+
+    def build() -> Path:
+        calls.append(1)
+        database_path = tmp_path / f"built-{len(calls)}.sqlite"
+        with sqlite3.connect(database_path) as connection:
+            connection.execute("CREATE TABLE t (v TEXT)")
+            connection.execute("INSERT INTO t VALUES (?)", (content,))
+        return database_path
+
+    return build
+
+
+def _read_back(database_path: Path) -> list[str]:
+    with sqlite3.connect(database_path) as connection:
+        return [row[0] for row in connection.execute("SELECT v FROM t")]
+
+
+# ---------------------------------------------------------------------------------------------
+# enabling
+# ---------------------------------------------------------------------------------------------
+
+
+def test_disabled_by_default_builds_every_time(
+    paths: CachePaths, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(_ENV_VAR, raising=False)
+    calls: list[int] = []
+    builder = _counting_builder(tmp_path, calls)
+
+    first = cached_db("some-key", builder, paths=paths)  # type: ignore[arg-type]
+    second = cached_db("some-key", builder, paths=paths)  # type: ignore[arg-type]
+
+    assert len(calls) == 2, "with the cache disabled every call must build"
+    assert _read_back(first) == ["payload"]
+    assert _read_back(second) == ["payload"]
+    assert not paths.cache_dir.exists(), "a disabled cache must not create anything on disk"
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "", "  "])
+def test_non_enabling_values_keep_the_cache_off(
+    value: str, paths: CachePaths, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(_ENV_VAR, value)
+    calls: list[int] = []
+
+    cached_db("some-key", _counting_builder(tmp_path, calls), paths=paths)  # type: ignore[arg-type]
+    cached_db("some-key", _counting_builder(tmp_path, calls), paths=paths)  # type: ignore[arg-type]
+
+    assert not is_enabled()
+    assert len(calls) == 2
+    assert not paths.cache_dir.exists()
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "Yes"])
+def test_enabling_values_switch_the_cache_on(value: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_ENV_VAR, value)
+    assert is_enabled()
+
+
+def test_enabled_builds_once_and_serves_copies(
+    paths: CachePaths, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(_ENV_VAR, "1")
+    calls: list[int] = []
+    builder = _counting_builder(tmp_path, calls)
+
+    first = cached_db("some-key", builder, paths=paths)  # type: ignore[arg-type]
+    second = cached_db("some-key", builder, paths=paths)  # type: ignore[arg-type]
+
+    assert len(calls) == 1, "the second request must be served from the cache"
+    assert _read_back(first) == _read_back(second) == ["payload"]
+    assert first != second, "every caller gets its own copy"
+
+
+def test_different_keys_do_not_share_an_entry(
+    paths: CachePaths, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(_ENV_VAR, "1")
+    calls: list[int] = []
+
+    cached_db("key-a", _counting_builder(tmp_path, calls, "a"), paths=paths)  # type: ignore[arg-type]
+    second = cached_db("key-b", _counting_builder(tmp_path, calls, "b"), paths=paths)  # type: ignore[arg-type]
+
+    assert len(calls) == 2
+    assert _read_back(second) == ["b"]
+
+
+def test_unusable_cache_directory_falls_back_to_building(
+    paths: CachePaths, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(_ENV_VAR, "1")
+    # A *file* where the cache directory should go: mkdir fails on every platform, unlike a
+    # read-only directory, which does not reliably block writes on Windows.
+    blocked = tmp_path / "blocked"
+    blocked.write_text("not a directory", encoding="utf-8")
+    unusable = CachePaths(
+        repo_root=paths.repo_root,
+        source_root=paths.source_root,
+        lock_path=paths.lock_path,
+        unittests_root=paths.unittests_root,
+        cache_dir=blocked,
+    )
+    calls: list[int] = []
+
+    with pytest.warns(UserWarning, match="cache unusable"):
+        built = cached_db("some-key", _counting_builder(tmp_path, calls), paths=unusable)  # type: ignore[arg-type]
+
+    assert len(calls) == 1
+    assert _read_back(built) == ["payload"], "a broken cache must never break the run"
+
+
+# ---------------------------------------------------------------------------------------------
+# the fingerprint: what must and must not change the key
+# ---------------------------------------------------------------------------------------------
+
+
+def test_fingerprint_is_stable_for_identical_inputs(paths: CachePaths) -> None:
+    files = [_make_input(paths, "MSCONS_AHB.xml")]
+    assert fingerprint("recipe", files, paths=paths) == fingerprint("recipe", files, paths=paths)
+
+
+def test_fingerprint_ignores_input_order(paths: CachePaths) -> None:
+    one = _make_input(paths, "one.xml", "<one/>")
+    two = _make_input(paths, "two.xml", "<two/>")
+    assert fingerprint("recipe", [one, two], paths=paths) == fingerprint("recipe", [two, one], paths=paths)
+
+
+def test_recipe_change_invalidates(paths: CachePaths) -> None:
+    files = [_make_input(paths, "MSCONS_AHB.xml")]
+    assert fingerprint("ahb_raw_drop0", files, paths=paths) != fingerprint("ahb_raw_drop1", files, paths=paths)
+
+
+def test_input_content_change_invalidates(paths: CachePaths) -> None:
+    file = _make_input(paths, "MSCONS_AHB.xml", "<AHB>old</AHB>")
+    before = fingerprint("recipe", [file], paths=paths)
+    file.write_text("<AHB>new</AHB>", encoding="utf-8")
+    assert fingerprint("recipe", [file], paths=paths) != before
+
+
+def test_input_validity_dates_change_invalidates(paths: CachePaths) -> None:
+    file = _make_input(paths, "MSCONS_AHB.xml")
+    early = fingerprint("recipe", [(file, date(2024, 10, 1), None)], paths=paths)
+    late = fingerprint("recipe", [(file, date(2025, 6, 6), None)], paths=paths)
+    assert early != late
+
+
+def _fingerprint_of_variant(paths: CachePaths, mutate: object) -> str:
+    """Build a second, independent stub tree that differs only as ``mutate`` says, and hash it."""
+    variant_root = paths.repo_root.parent / "repo-variant"
+    if variant_root.exists():
+        raise AssertionError("variant root must be built exactly once per test")
+    variant_source = variant_root / "src" / "fundamend"
+    variant_unittests = variant_root / "unittests"
+    variant_source.mkdir(parents=True)
+    variant_unittests.mkdir(parents=True)
+    for source, destination in (
+        (paths.source_root, variant_source),
+        (paths.unittests_root, variant_unittests),
+    ):
+        for path in source.rglob("*"):
+            if path.is_file():
+                target = destination / path.relative_to(source)
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_bytes(path.read_bytes())
+    variant_lock = variant_root / "uv.lock"
+    variant_lock.write_bytes(paths.lock_path.read_bytes())
+    variant = CachePaths(
+        repo_root=variant_root,
+        source_root=variant_source,
+        lock_path=variant_lock,
+        unittests_root=variant_unittests,
+        cache_dir=variant_root / "cache",
+    )
+    mutate(variant)  # type: ignore[operator]
+    # the same input file, at the same repo-relative path, so only the code differs
+    input_file = variant_root / "xml-migs-and-ahbs" / "MSCONS_AHB.xml"
+    input_file.parent.mkdir(parents=True, exist_ok=True)
+    input_file.write_text("<AHB/>", encoding="utf-8")
+    return fingerprint("recipe", [input_file], paths=variant)
+
+
+def test_python_source_change_invalidates(paths: CachePaths) -> None:
+    baseline = _make_input(paths, "MSCONS_AHB.xml")
+    before = fingerprint("recipe", [baseline], paths=paths)
+    after = _fingerprint_of_variant(
+        paths, lambda variant: (variant.source_root / "ahbview.py").write_text("def build(): return 1\n")
+    )
+    assert after != before, "a change to a builder module must invalidate the cache"
+
+
+def test_sql_source_change_invalidates(paths: CachePaths) -> None:
+    baseline = _make_input(paths, "MSCONS_AHB.xml")
+    before = fingerprint("recipe", [baseline], paths=paths)
+    after = _fingerprint_of_variant(
+        paths,
+        lambda variant: (variant.source_root / "materialize_ahb_view.sql").write_text("select 2;\n"),
+    )
+    assert after != before, (
+        "the .sql view definitions are read at runtime and executed into the database, "
+        "so editing one must invalidate the cache"
+    )
+
+
+def test_new_source_file_invalidates(paths: CachePaths) -> None:
+    baseline = _make_input(paths, "MSCONS_AHB.xml")
+    before = fingerprint("recipe", [baseline], paths=paths)
+    after = _fingerprint_of_variant(
+        paths, lambda variant: (variant.source_root / "new_view.sql").write_text("select 3;\n")
+    )
+    assert after != before
+
+
+def test_lock_file_change_invalidates(paths: CachePaths) -> None:
+    baseline = _make_input(paths, "MSCONS_AHB.xml")
+    before = fingerprint("recipe", [baseline], paths=paths)
+    after = _fingerprint_of_variant(paths, lambda variant: variant.lock_path.write_text("ahbicht==2.0.0\n"))
+    assert after != before, "a dependency bump changes what ahb_expressions contains"
+
+
+def test_unittests_change_invalidates(paths: CachePaths) -> None:
+    baseline = _make_input(paths, "MSCONS_AHB.xml")
+    before = fingerprint("recipe", [baseline], paths=paths)
+    after = _fingerprint_of_variant(
+        paths, lambda variant: (variant.unittests_root / "conftest.py").write_text("# different fixtures\n")
+    )
+    assert after != before, "the fixtures decide which views a built database receives"
+
+
+def test_ignored_directories_do_not_invalidate(paths: CachePaths) -> None:
+    baseline = _make_input(paths, "MSCONS_AHB.xml")
+    before = fingerprint("recipe", [baseline], paths=paths)
+
+    def add_ignored_files(variant: CachePaths) -> None:
+        snapshots = variant.unittests_root / "__snapshots__"
+        snapshots.mkdir()
+        (snapshots / "test_something.ambr").write_text("# serializer version: 1\n", encoding="utf-8")
+        examples = variant.unittests_root / "example_files"
+        examples.mkdir()
+        (examples / "UTILTS_AHB.xml").write_text("<AHB/>\n", encoding="utf-8")
+        (variant.unittests_root / "conftest.pyc").write_bytes(b"\x00compiled")
+
+    after = _fingerprint_of_variant(paths, add_ignored_files)
+    assert after == before, "snapshots, example files and bytecode do not change how a database is built"

--- a/unittests/test_mig_views.py
+++ b/unittests/test_mig_views.py
@@ -22,7 +22,7 @@ from fundamend.sqlmodels import (
     create_mig_view,
 )
 
-from .conftest import is_private_submodule_checked_out, private_submodule_root
+from .conftest import cached_mig_db, is_private_submodule_checked_out, private_submodule_root
 
 
 @pytest.fixture()
@@ -147,7 +147,7 @@ def test_mig_diff_view_with_two_versions() -> None:
         (fv2504_migs[0], date(2025, 6, 6), None),
     ]
 
-    actual_sqlite_path = create_db_and_populate_with_mig_view(mig_files=mig_paths, drop_raw_tables=False)
+    actual_sqlite_path = cached_mig_db(mig_files=mig_paths, drop_raw_tables=False)
     engine = create_engine(f"sqlite:///{actual_sqlite_path}")
 
     with Session(bind=engine) as session:
@@ -205,7 +205,7 @@ def test_mig_hierarchy_all_from_submodule() -> None:
     # Use just the first few MIGs to keep test reasonable
     mig_paths = mig_paths[:5]
 
-    actual_sqlite_path = create_db_and_populate_with_mig_view(mig_files=mig_paths)
+    actual_sqlite_path = cached_mig_db(mig_files=mig_paths)
     assert actual_sqlite_path.exists()
 
     engine = create_engine(f"sqlite:///{actual_sqlite_path}")
@@ -233,7 +233,7 @@ def test_mig_diff_snapshot_comdis(snapshot: SnapshotAssertion) -> None:
         (fv2504_comdis, date(2025, 6, 6), None),
     ]
 
-    actual_sqlite_path = create_db_and_populate_with_mig_view(mig_files=mig_paths, drop_raw_tables=False)
+    actual_sqlite_path = cached_mig_db(mig_files=mig_paths, drop_raw_tables=False)
     engine = create_engine(f"sqlite:///{actual_sqlite_path}")
 
     with Session(bind=engine) as session:
@@ -271,7 +271,7 @@ def test_mig_diff_snapshot_pricat(snapshot: SnapshotAssertion) -> None:
         (fv2504_pricat, date(2025, 6, 6), None),
     ]
 
-    actual_sqlite_path = create_db_and_populate_with_mig_view(mig_files=mig_paths, drop_raw_tables=False)
+    actual_sqlite_path = cached_mig_db(mig_files=mig_paths, drop_raw_tables=False)
     engine = create_engine(f"sqlite:///{actual_sqlite_path}")
 
     with Session(bind=engine) as session:
@@ -309,7 +309,7 @@ def test_mig_diff_snapshot_iftsta(snapshot: SnapshotAssertion) -> None:
         (fv2510_iftsta, date(2025, 10, 1), None),
     ]
 
-    actual_sqlite_path = create_db_and_populate_with_mig_view(mig_files=mig_paths, drop_raw_tables=False)
+    actual_sqlite_path = cached_mig_db(mig_files=mig_paths, drop_raw_tables=False)
     engine = create_engine(f"sqlite:///{actual_sqlite_path}")
 
     with Session(bind=engine) as session:

--- a/unittests/test_sqlmodels_anwendungshandbuch.py
+++ b/unittests/test_sqlmodels_anwendungshandbuch.py
@@ -19,7 +19,7 @@ from fundamend.models.kommunikationsrichtung import Kommunikationsrichtung
 from fundamend.sqlmodels import AhbHierarchyMaterialized, create_ahb_view, create_db_and_populate_with_ahb_view
 from fundamend.sqlmodels import Anwendungshandbuch as SqlAnwendungshandbuch
 
-from .conftest import apply_throwaway_sqlite_pragmas, is_private_submodule_checked_out
+from .conftest import apply_throwaway_sqlite_pragmas, cached_ahb_db, is_private_submodule_checked_out
 
 
 @pytest.fixture()
@@ -185,9 +185,7 @@ def test_create_sqlite_from_submodule() -> None:
         pytest.skip("Skipping test because of missing private submodule")
     private_submodule_root = Path(__file__).parent.parent / "xml-migs-and-ahbs"
     assert private_submodule_root.exists() and private_submodule_root.is_dir()
-    actual_sqlite_path = create_db_and_populate_with_ahb_view(
-        ahb_files=list(private_submodule_root.rglob("**/*AHB*.xml"))
-    )
+    actual_sqlite_path = cached_ahb_db(list(private_submodule_root.rglob("**/*AHB*.xml")))
     assert actual_sqlite_path.exists()
 
 
@@ -198,7 +196,7 @@ def test_create_sqlite_from_submodule_with_validity() -> None:
     relevant_files = [
         (p, date(2024, 10, 1), date(2025, 6, 6)) for p in (private_submodule_root / "FV2410").rglob("**/*AHB*.xml")
     ] + [(p, date(2025, 6, 6), None) for p in (private_submodule_root / "FV2504").rglob("**/*AHB*.xml")]
-    actual_sqlite_path = create_db_and_populate_with_ahb_view(ahb_files=relevant_files, drop_raw_tables=True)
+    actual_sqlite_path = cached_ahb_db(relevant_files, drop_raw_tables=True)
     assert actual_sqlite_path.exists()
     engine = create_engine(f"sqlite:///{actual_sqlite_path}")
     with Session(bind=engine) as session:
@@ -289,7 +287,7 @@ def test_sqlmodels_all_id_path_uniqueness(format_version: str, gueltig_von: date
     if not format_version_path.exists():
         pytest.skip(f"Format version {format_version} not found in submodule")
     relevant_files = [(p, gueltig_von, gueltig_bis) for p in format_version_path.rglob("**/*AHB*.xml")]
-    actual_sqlite_path = create_db_and_populate_with_ahb_view(ahb_files=relevant_files, drop_raw_tables=False)
+    actual_sqlite_path = cached_ahb_db(relevant_files, drop_raw_tables=False)
     _check_uniqueness_of_id_paths(actual_sqlite_path)
 
 
@@ -324,7 +322,7 @@ def test_id_path_uniqueness_per_message_type(message_type: str) -> None:
     ]
     if not relevant_files:
         pytest.skip(f"No AHB files found for {message_type}")
-    actual_sqlite_path = create_db_and_populate_with_ahb_view(ahb_files=relevant_files, drop_raw_tables=False)
+    actual_sqlite_path = cached_ahb_db(relevant_files, drop_raw_tables=False)
     _check_uniqueness_of_id_paths(actual_sqlite_path)
     _check_id_paths_use_qualifiers_not_sort_path(actual_sqlite_path)
 
@@ -346,7 +344,7 @@ def test_id_path_stable_across_versions_utilmd() -> None:
     ] + [(p, date(2026, 4, 1), None) for p in fv2604_path.rglob("**/UTILMD_AHB*Strom*.xml")]
     if not relevant_files:
         pytest.skip("No UTILMD Strom AHB files found")
-    actual_sqlite_path = create_db_and_populate_with_ahb_view(ahb_files=relevant_files, drop_raw_tables=False)
+    actual_sqlite_path = cached_ahb_db(relevant_files, drop_raw_tables=False)
     _check_uniqueness_of_id_paths(actual_sqlite_path)
 
     # Verify cross-version id_path overlap: most id_paths from FV2510 should also exist in FV2604

--- a/unittests/test_sqlmodels_expressions_view.py
+++ b/unittests/test_sqlmodels_expressions_view.py
@@ -5,10 +5,9 @@ import pytest
 from sqlmodel import Session, col, create_engine, select
 from syrupy.assertion import SnapshotAssertion
 
-from fundamend.sqlmodels import create_db_and_populate_with_ahb_view
 from fundamend.sqlmodels.expression_view import AhbExpression, create_and_fill_ahb_expression_table
 
-from .conftest import is_private_submodule_checked_out
+from .conftest import cached_ahb_db, is_private_submodule_checked_out
 
 
 @pytest.mark.snapshot
@@ -20,7 +19,7 @@ def test_create_db_and_expressions_view(snapshot: SnapshotAssertion) -> None:
             date(2024, 4, 3),
         )
     ]
-    actual_sqlite_path = create_db_and_populate_with_ahb_view(ahb_files=ahb_paths, drop_raw_tables=True)
+    actual_sqlite_path = cached_ahb_db(ahb_paths, drop_raw_tables=True)
     assert actual_sqlite_path.exists()
     engine = create_engine(f"sqlite:///{actual_sqlite_path}")
     with Session(bind=engine) as session:
@@ -43,7 +42,7 @@ def test_create_expressions_table_from_submodule_with_validity(snapshot: Snapsho
     relevant_files = [
         (p, date(2024, 10, 1), date(2025, 6, 6)) for p in (private_submodule_root / "FV2410").rglob("**/*AHB*.xml")
     ] + [(p, date(2025, 6, 6), None) for p in (private_submodule_root / "FV2504").rglob("**/*AHB*.xml")]
-    actual_sqlite_path = create_db_and_populate_with_ahb_view(ahb_files=relevant_files, drop_raw_tables=True)
+    actual_sqlite_path = cached_ahb_db(relevant_files, drop_raw_tables=True)
     assert actual_sqlite_path.exists()
     engine = create_engine(f"sqlite:///{actual_sqlite_path}")
     with Session(bind=engine) as session:

--- a/uv.lock
+++ b/uv.lock
@@ -259,6 +259,7 @@ sqlmodels = [
 [package.dev-dependencies]
 coverage = [
     { name = "coverage" },
+    { name = "filelock" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
@@ -267,6 +268,7 @@ coverage = [
 dev = [
     { name = "codespell" },
     { name = "coverage" },
+    { name = "filelock" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -282,11 +284,13 @@ spell-check = [
     { name = "codespell" },
 ]
 tests = [
+    { name = "filelock" },
     { name = "pytest" },
     { name = "pytest-xdist" },
     { name = "syrupy" },
 ]
 type-check = [
+    { name = "filelock" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-xdist" },
@@ -307,6 +311,7 @@ provides-extras = ["ahbicht", "cli", "sqlmodels"]
 [package.metadata.requires-dev]
 coverage = [
     { name = "coverage", specifier = "==7.15.3" },
+    { name = "filelock", specifier = "==3.32.2" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "pytest-xdist", specifier = "==3.8.0" },
@@ -315,6 +320,7 @@ coverage = [
 dev = [
     { name = "codespell", specifier = "==2.4.3" },
     { name = "coverage", specifier = "==7.15.3" },
+    { name = "filelock", specifier = "==3.32.2" },
     { name = "mypy", specifier = "==2.3.0" },
     { name = "pre-commit" },
     { name = "pytest", specifier = "==9.1.1" },
@@ -326,11 +332,13 @@ dev = [
 lint = [{ name = "ruff", specifier = "==0.16.1" }]
 spell-check = [{ name = "codespell", specifier = "==2.4.3" }]
 tests = [
+    { name = "filelock", specifier = "==3.32.2" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "syrupy", specifier = "==5.5.3" },
 ]
 type-check = [
+    { name = "filelock", specifier = "==3.32.2" },
     { name = "mypy", specifier = "==2.3.0" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-xdist", specifier = "==3.8.0" },


### PR DESCRIPTION
Implements the design merged in #323.

## What you get

```bash
export FUNDAMEND_TEST_DB_CACHE=1
uv run pytest
```

Unset — which is every CI run, since no workflow is touched by this PR — `cached_db()` calls the builder and returns. No directory, no lock, no copy. The cache is not "off"; it does not execute.

## Why this one cannot hide a code change

`fingerprint()` hashes every file under `src/fundamend` (including the six `.sql` view definitions `_execute_bare_sql` reads at runtime), `uv.lock`, and the test sources — on top of the input XML. Any change to how a database is built changes the key on its own, so there is no `_CACHE_VERSION` to bump and no invariant anyone can break by forgetting.

`unittests/test_db_cache.py` pins that down in **25 fast tests, no submodule needed** (16 s locally, all green). The invalidation cases are deliberately regression tests for #321's defect — narrow the key back to the input data and they fail:

| Change | Effect |
|---|---|
| `.py` source | invalidates |
| **`.sql` source** | invalidates |
| new source file | invalidates |
| `uv.lock` | invalidates |
| test sources | invalidates |
| recipe / `drop_raw_tables` | invalidates |
| input contents, path, validity dates | invalidates |
| snapshots, example files, `.pyc` | do **not** invalidate |

## Two fixes over the original implementation

- **Paths are hashed repo-relative and POSIX-normalised.** The old code hashed `str(path)`, so the key depended on where your checkout lived and on the path separator — moving a checkout silently discarded the entire cache.
- **Publication is explicitly atomic** (copy to a temp name, then `Path.replace`). The file lock only serialises xdist workers within one run; atomicity is what stops an interrupted run (Ctrl-C, OOM) leaving a truncated `.sqlite` that every later run reuses.

Any filesystem problem degrades to a direct build with a warning. The cache never gets a vote on whether the suite can run.

## Verification

`ruff check`, `ruff format --check`, `mypy --strict` and both `codespell` invocations pass locally, and the full suite collects (315 tests). I ran **only** `unittests/test_db_cache.py` locally — the submodule-scale tests take ~1.5 h, so CI is the honest check on those, and it exercises the uncached path by construction.

## Known trade-offs, both deliberate

- `uv.lock` also pins `ruff`/`mypy`/`pytest`, so a lint-tool bump invalidates every local entry. Wasteful, never wrong; the alternative is an exceptions list someone has to maintain.
- Hashing `unittests/**/*.py` means editing any test file invalidates your local entries. That is what stops builder logic silently escaping the key if it ever moves out of `conftest.py`.

If the day-to-day hit rate is worse than this predicts, those two are the knobs, and both are easy to narrow.